### PR TITLE
feat: mobile touch controls for movement and jump

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,7 +1,8 @@
 ; TODO: parallax layers, fog particles, drifting lights, door nodes
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/Curiosity.tscn" id="1_curiosity"]
+[ext_resource type="PackedScene" path="res://scenes/TouchControls.tscn" id="2_touch"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_floor"]
 size = Vector2(3000, 40)
@@ -24,3 +25,5 @@ shape = SubResource("RectangleShape2D_floor")
 
 [node name="Curiosity" parent="." instance=ExtResource("1_curiosity")]
 position = Vector2(400, 300)
+
+[node name="TouchControls" parent="." instance=ExtResource("2_touch")]

--- a/scenes/TouchControls.tscn
+++ b/scenes/TouchControls.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/TouchControls.gd" id="1_touch"]
+
+[sub_resource type="Gradient" id="Gradient_glow"]
+offsets = PackedFloat32Array(0, 0.6, 1)
+colors = PackedColorArray(0.961, 0.722, 0.439, 0.85, 0.961, 0.722, 0.439, 0.4, 0.961, 0.722, 0.439, 0)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_glow"]
+gradient = SubResource("Gradient_glow")
+width = 140
+height = 140
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 0.5)
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_button"]
+radius = 70.0
+
+[node name="TouchControls" type="CanvasLayer"]
+layer = 10
+script = ExtResource("1_touch")
+
+[node name="LeftButton" type="TouchScreenButton" parent="."]
+texture_normal = SubResource("GradientTexture2D_glow")
+shape = SubResource("CircleShape2D_button")
+shape_visible = false
+action = &"move_left"
+
+[node name="LeftArrow" type="Polygon2D" parent="LeftButton"]
+position = Vector2(70, 70)
+color = Color(0.961, 0.722, 0.439, 0.95)
+polygon = PackedVector2Array(-18, 0, 12, -16, 12, 16)
+
+[node name="RightButton" type="TouchScreenButton" parent="."]
+texture_normal = SubResource("GradientTexture2D_glow")
+shape = SubResource("CircleShape2D_button")
+shape_visible = false
+action = &"move_right"
+
+[node name="RightArrow" type="Polygon2D" parent="RightButton"]
+position = Vector2(70, 70)
+color = Color(0.961, 0.722, 0.439, 0.95)
+polygon = PackedVector2Array(18, 0, -12, -16, -12, 16)
+
+[node name="JumpButton" type="TouchScreenButton" parent="."]
+texture_normal = SubResource("GradientTexture2D_glow")
+shape = SubResource("CircleShape2D_button")
+shape_visible = false
+action = &"jump"
+
+[node name="JumpArrow" type="Polygon2D" parent="JumpButton"]
+position = Vector2(70, 70)
+color = Color(0.961, 0.722, 0.439, 0.95)
+polygon = PackedVector2Array(0, -18, -16, 12, 16, 12)

--- a/scripts/TouchControls.gd
+++ b/scripts/TouchControls.gd
@@ -1,0 +1,60 @@
+extends CanvasLayer
+
+const IDLE_ALPHA: float = 0.35
+const PRESSED_ALPHA: float = 1.0
+const FADE_TIME: float = 0.18
+const BUTTON_RADIUS: float = 70.0
+const EDGE_PADDING: float = 80.0
+const BUTTON_GAP: float = 30.0
+
+@onready var _left: TouchScreenButton = $LeftButton
+@onready var _right: TouchScreenButton = $RightButton
+@onready var _jump: TouchScreenButton = $JumpButton
+
+var _tweens: Dictionary = {}
+
+
+func _ready() -> void:
+	visible = _should_show_touch_ui()
+	if not visible:
+		return
+	_wire_button(_left)
+	_wire_button(_right)
+	_wire_button(_jump)
+	get_viewport().size_changed.connect(_layout_buttons)
+	_layout_buttons()
+
+
+func _should_show_touch_ui() -> bool:
+	return DisplayServer.is_touchscreen_available() or OS.has_feature("mobile")
+
+
+func _wire_button(btn: TouchScreenButton) -> void:
+	btn.modulate.a = IDLE_ALPHA
+	btn.pressed.connect(_on_pressed.bind(btn))
+	btn.released.connect(_on_released.bind(btn))
+
+
+func _on_pressed(btn: TouchScreenButton) -> void:
+	_fade(btn, PRESSED_ALPHA)
+
+
+func _on_released(btn: TouchScreenButton) -> void:
+	_fade(btn, IDLE_ALPHA)
+
+
+func _fade(btn: TouchScreenButton, target_alpha: float) -> void:
+	var existing: Tween = _tweens.get(btn)
+	if existing and existing.is_valid():
+		existing.kill()
+	var tween := create_tween()
+	tween.tween_property(btn, "modulate:a", target_alpha, FADE_TIME)
+	_tweens[btn] = tween
+
+
+func _layout_buttons() -> void:
+	var size: Vector2 = get_viewport().get_visible_rect().size
+	var top_y: float = size.y - EDGE_PADDING - BUTTON_RADIUS * 2.0
+	_left.position = Vector2(EDGE_PADDING, top_y)
+	_right.position = Vector2(EDGE_PADDING + BUTTON_RADIUS * 2.0 + BUTTON_GAP, top_y)
+	_jump.position = Vector2(size.x - EDGE_PADDING - BUTTON_RADIUS * 2.0, top_y)

--- a/scripts/TouchControls.gd.uid
+++ b/scripts/TouchControls.gd.uid
@@ -1,0 +1,1 @@
+uid://ca5lwsblnd2sp


### PR DESCRIPTION
Closes #2

## Summary
Auto-detected on-screen touch HUD so the live web build is playable on phones. Three semi-transparent lantern-gold buttons: left + right at bottom-left, jump at bottom-right.

- **Detection:** `DisplayServer.is_touchscreen_available()` OR `OS.has_feature("mobile")` — invisible on desktop browsers, visible on touch devices.
- **Visual:** soft circular `GradientTexture2D` glows in lantern gold (`#f5b870`), minimal arrow `Polygon2D` overlays. No system-UI rectangles.
- **Idle vs pressed:** alpha 0.35 at rest, tweens to 1.0 on press, fades back on release (FADE_TIME 0.18s).
- **Wiring:** `TouchScreenButton.action` mapped directly to the existing input actions (`move_left`, `move_right`, `jump`). `Curiosity.gd` is untouched — keyboard play unaffected.
- **Multitouch:** independent buttons, so holding direction + tapping jump works.
- **Responsive layout:** positions recompute on viewport `size_changed` for portrait/landscape and browser resizes.

## Verification
- [x] `godot --headless --import` passes
- [x] `godot --headless --export-release "Web" build/index.html` passes (full set: index.html / .js / .wasm / .pck / audio worklets / icons)
- [x] CanvasModulate, lantern PointLight2D, and Curiosity movement still behave as before
- [ ] **Phone test on live site** — assigning to Advik post-merge: load the live URL on phone, confirm buttons appear, confirm hold-direction + tap-jump works
- [x] Adheres to docs/ART_DIRECTION.md (lantern gold, soft falloff, near-zero UI) and docs/VIBE.md (restraint, no hard rectangles)
- [x] No CLAUDE.md / docs/ changes needed — this builds on the existing input action contract

## Screenshots / clips
None attached — desktop preview hides the controls by design (auto-detect). Visual confirmation will come from the live site on phone after merge.

## Notes for reviewer
- **Placeholder geometry, not painted art.** The `GradientTexture2D` glows + Polygon2D arrows are placeholder visuals — same scaffold style as the lantern's current radial gradient. A future `art:` issue can swap them for hand-painted glyphs once the painterly pass begins.
- **Padding / sizes are tuned for 1280×720 reference viewport.** They scale by recomputing against the actual viewport, but on tiny portrait screens the buttons may feel large. Easy to tune via the constants at the top of `scripts/TouchControls.gd` if it's off.
- Tested locally that the export still produces all expected files. Non-fatal `icon.svg` warning is pre-existing (project icon never committed).