### PR TITLE
fix: lock web build to landscape orientation

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -23,6 +23,9 @@ config_version=5
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
+window/handheld/orientation="sensor_landscape"
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
 
 [input]
 


### PR DESCRIPTION
Closes #4

## Summary
Three lines in `project.godot` to fix phone playtest:
- `display/window/handheld/orientation = "sensor_landscape"` — locks browser to landscape (regular OR reverse)
- `display/window/stretch/mode = "canvas_items"` — scales the canvas cleanly for any screen
- `display/window/stretch/aspect = "expand"` — extends viewport to match phone aspect ratio so the play area fills the screen instead of letterboxing

`TouchControls.gd` already reads viewport size at runtime, so the buttons re-anchor automatically with the new stretch behavior.

## Verification
- [x] `godot --headless --import` passes
- [x] `godot --headless --export-release "Web" build/index.html` passes
- [ ] Phone test post-merge: open live site → should now load in landscape
- [x] Desktop browser layout untouched

## Notes for reviewer
iOS Safari has historically been spotty about respecting orientation locks for non-fullscreen pages — if it still loads portrait on iPhone, the fallback is a "rotate your device" overlay scene; cheap to add as a follow-up.