### PR TITLE
fix(hero): scale up Curiosity and flip sprite based on movement direction

### DIFF
--- a/scenes/Curiosity.tscn
+++ b/scenes/Curiosity.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" path="res://assets/characters/hero/curiosity.png" id="2_curiosity_art"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_body"]
-size = Vector2(22, 88)
+size = Vector2(44, 176)
 
 [sub_resource type="Gradient" id="Gradient_lantern"]
 offsets = PackedFloat32Array(0, 1)
@@ -23,13 +23,13 @@ script = ExtResource("1_curiosity")
 
 [node name="Visual" type="Sprite2D" parent="."]
 texture = ExtResource("2_curiosity_art")
-scale = Vector2(0.08, 0.08)
+scale = Vector2(0.16, 0.16)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_body")
 
 [node name="Lantern" type="PointLight2D" parent="."]
-position = Vector2(18, 8)
+position = Vector2(36, 16)
 color = Color(1, 0.78, 0.42, 1)
 energy = 1.1
 texture = SubResource("GradientTexture2D_lantern")

--- a/scripts/Curiosity.gd
+++ b/scripts/Curiosity.gd
@@ -4,6 +4,18 @@ extends CharacterBody2D
 @export var gravity: float = 980.0
 @export var jump_velocity: float = -400.0
 
+@onready var visual: Sprite2D = $Visual
+@onready var lantern: PointLight2D = $Lantern
+
+# Lantern offset is mirrored on flip — the painted lantern in the source
+# image sits to the viewer's right, so when the sprite flips to face right
+# the light has to move with it. Cached on ready from the scene's own value.
+var _lantern_offset_x: float
+
+
+func _ready() -> void:
+	_lantern_offset_x = abs(lantern.position.x)
+
 
 func _physics_process(delta: float) -> void:
 	if not is_on_floor():
@@ -17,6 +29,13 @@ func _physics_process(delta: float) -> void:
 		velocity.x = direction * speed
 	else:
 		velocity.x = move_toward(velocity.x, 0.0, speed)
+
+	if velocity.x > 0.1:
+		visual.flip_h = true
+		lantern.position.x = -_lantern_offset_x
+	elif velocity.x < -0.1:
+		visual.flip_h = false
+		lantern.position.x = _lantern_offset_x
 
 	# TODO: cloak sway animation
 	# TODO: lantern flicker


### PR DESCRIPTION
Closes #8

## Summary
Two follow-ups on the character art swap (Visual pillar):

1. **Size** — `Sprite2D` scale `0.08` → `0.16`. Source PNG is 921×1152, so displayed sprite is now ~147×184px, with the visible figure ~165px tall (within the requested 140–180 band). `CollisionShape2D` resized 22×88 → 44×176 to match — still tight to the body silhouette, not the trailing cloak. `PointLight2D` anchor doubled `(18,8)` → `(36,16)` to follow the new scale.
2. **Facing direction** — source art faces left, so the sprite previously always faced left. `Curiosity.gd` now reads `velocity.x` each physics frame and:
   - `> 0.1` → `Sprite2D.flip_h = true` (faces right), lantern x mirrored to `-_lantern_offset_x`
   - `< -0.1` → `Sprite2D.flip_h = false` (faces left), lantern x set to `+_lantern_offset_x`
   - between → no change, last facing held (idle does not snap back to default mid-stand)

   `_lantern_offset_x` is cached in `_ready()` from the scene's lantern position, so the script doesn't hardcode the value — if the offset gets retuned in the scene, the script keeps following.

## Verification
- [x] `godot --headless --import` passes (exit 0)
- [x] `godot --headless --export-release "Web" build/index.html` passes (exit 0; pre-existing `icon.svg` warning unchanged)
- [ ] Played on the live site after merge
- [x] No regression in feel: speed/gravity/jump constants and movement loop unchanged

## Notes for reviewer
The 0.1 dead-band on `velocity.x` is there because `move_toward` decays through tiny non-zero values when the player releases the move key — without it, the lantern would jitter/flip on the deceleration tail. 0.1 is small enough to not affect intent, large enough to swallow the decay.