### PR TITLE
fix(hero): 4x scale Curiosity and correct sprite flip on movement

### DIFF
--- a/scenes/Curiosity.tscn
+++ b/scenes/Curiosity.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" path="res://assets/characters/hero/curiosity.png" id="2_curiosity_art"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_body"]
-size = Vector2(44, 176)
+size = Vector2(176, 704)
 
 [sub_resource type="Gradient" id="Gradient_lantern"]
 offsets = PackedFloat32Array(0, 1)
@@ -23,13 +23,13 @@ script = ExtResource("1_curiosity")
 
 [node name="Visual" type="Sprite2D" parent="."]
 texture = ExtResource("2_curiosity_art")
-scale = Vector2(0.16, 0.16)
+scale = Vector2(0.64, 0.64)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_body")
 
 [node name="Lantern" type="PointLight2D" parent="."]
-position = Vector2(36, 16)
+position = Vector2(144, 64)
 color = Color(1, 0.78, 0.42, 1)
 energy = 1.1
 texture = SubResource("GradientTexture2D_lantern")

--- a/scripts/Curiosity.gd
+++ b/scripts/Curiosity.gd
@@ -7,14 +7,17 @@ extends CharacterBody2D
 @onready var visual: Sprite2D = $Visual
 @onready var lantern: PointLight2D = $Lantern
 
-# Lantern offset is mirrored on flip — the painted lantern in the source
-# image sits to the viewer's right, so when the sprite flips to face right
-# the light has to move with it. Cached on ready from the scene's own value.
+# Source art (curiosity.png) faces LEFT by default. We track facing as a
+# state bool so idle holds the last input direction (no snap-back to default).
+var _facing_right: bool = false
+# Cached on ready from the scene's lantern position so the script doesn't
+# hardcode the offset — retune in the .tscn and the script keeps following.
 var _lantern_offset_x: float
 
 
 func _ready() -> void:
 	_lantern_offset_x = abs(lantern.position.x)
+	_apply_facing()
 
 
 func _physics_process(delta: float) -> void:
@@ -27,18 +30,23 @@ func _physics_process(delta: float) -> void:
 	var direction: float = Input.get_axis("move_left", "move_right")
 	if direction != 0.0:
 		velocity.x = direction * speed
+		# Update facing only on real input; idle holds the last direction.
+		var want_right: bool = direction > 0.0
+		if want_right != _facing_right:
+			_facing_right = want_right
+			_apply_facing()
 	else:
 		velocity.x = move_toward(velocity.x, 0.0, speed)
-
-	if velocity.x > 0.1:
-		visual.flip_h = true
-		lantern.position.x = -_lantern_offset_x
-	elif velocity.x < -0.1:
-		visual.flip_h = false
-		lantern.position.x = _lantern_offset_x
 
 	# TODO: cloak sway animation
 	# TODO: lantern flicker
 	# TODO: blinking eye shader on cloak
 
 	move_and_slide()
+
+
+func _apply_facing() -> void:
+	# Press LEFT  -> faces left  -> flip_h = false (source unflipped),  lantern at +offset
+	# Press RIGHT -> faces right -> flip_h = true  (source mirrored),   lantern at -offset
+	visual.flip_h = _facing_right
+	lantern.position.x = -_lantern_offset_x if _facing_right else _lantern_offset_x


### PR DESCRIPTION
Closes #10

## Summary
**Visual** pillar — Curiosity now reads as a real on-screen presence and faces the input direction.

1. `Sprite2D` scale `0.16` → `0.64` (4x). 921×1152 source displays at ~590×737, visible figure ~660px tall (within the 600–700 band requested in #10). `CollisionShape2D` scaled proportionally 44×176 → 176×704 (still tight to the body silhouette, not the trailing cloak). `PointLight2D` anchor `(36,16)` → `(144,64)` to track the painted lantern at the new scale.

2. Flip logic rewritten with an explicit `_facing_right` state bool plus `_apply_facing()` helper. Source art faces LEFT; defaults match that:
   - LEFT input → `_facing_right = false` → `flip_h = false` (source unflipped, faces left), lantern at `+offset`
   - RIGHT input → `_facing_right = true` → `flip_h = true` (mirrored, faces right), lantern at `-offset`
   - Idle (`direction == 0`) → state untouched → last facing held; no snap-back
   - PointLight2D x always mirrors with the sprite so the light stays on the painted lantern in either direction

   Switched the trigger from `velocity.x` to `Input.get_axis(...)` so deceleration tail can't accidentally re-trigger a flip during stop. Cleaner and removes the need for a dead-band.

## Heads-up (per the issue's "tell me, don't shrink it" clause)
At 4x scale the visible figure is ~660px tall. With `Main.tscn`'s floor at `y=500` (top surface y=480) the character settles with origin around `y=128`, which puts the head at roughly `y=-241` — clipping ~240px off the top of the 1280×720 viewport. That's a layout/camera fix in `Main.tscn`, not a sprite-scale fix, and is out of scope for this PR. Easy follow-ups when you want to address it: lower the floor (`Floor.position.y` → ~720), shrink the floor's collision so the surface lines up with viewport bottom, or add a camera that frames the character. Happy to do any of those next.

## Verification
- [x] `godot --headless --import` passes (exit 0)
- [x] `godot --headless --export-release "Web" build/index.html` passes (exit 0; pre-existing `icon.svg` warning unchanged)
- [ ] Played on the live site after merge
- [x] No regression in feel: speed/gravity/jump constants and movement loop unchanged

## Notes for reviewer
The `_facing_right` state bool replaces the previous direct-write-on-every-frame approach. `_apply_facing()` is only called when facing actually changes (and once at `_ready`), which is also a tiny perf win for what it's worth.