### PR TITLE
tune(hero): lower camera and slightly smaller Curiosity

### DIFF
--- a/scenes/Curiosity.tscn
+++ b/scenes/Curiosity.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" path="res://assets/characters/hero/curiosity.png" id="2_curiosity_art"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_body"]
-size = Vector2(110, 440)
+size = Vector2(88, 352)
 
 [sub_resource type="Gradient" id="Gradient_lantern"]
 offsets = PackedFloat32Array(0, 1)
@@ -23,19 +23,19 @@ script = ExtResource("1_curiosity")
 
 [node name="Visual" type="Sprite2D" parent="."]
 texture = ExtResource("2_curiosity_art")
-scale = Vector2(0.4, 0.4)
+scale = Vector2(0.32, 0.32)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_body")
 
 [node name="Lantern" type="PointLight2D" parent="."]
-position = Vector2(90, 40)
+position = Vector2(72, 32)
 color = Color(1, 0.78, 0.42, 1)
 energy = 1.1
 texture = SubResource("GradientTexture2D_lantern")
 texture_scale = 1.6
 
 [node name="Camera" type="Camera2D" parent="."]
-position = Vector2(0, -80)
+position = Vector2(0, -160)
 position_smoothing_enabled = true
 position_smoothing_speed = 6.0


### PR DESCRIPTION
Closes #14

## Summary
Two small follow-ups on PR #13.

- `Camera2D` offset `(0, -80)` → `(0, -160)`. With Curiosity standing on the floor at world `y ≈ 260`, camera now sits at `y ≈ 100`, putting the figure in the lower-middle of the 720px viewport — sky-heavy framing, modest floor below.
- `Sprite2D` scale `0.40` → `0.32` (80% of prior). Visible figure ~330px tall.
- `CollisionShape2D` `110×440` → `88×352`, lantern anchor `(90,40)` → `(72,32)` to match the new scale.

## Verification
- [x] `godot --headless --import` passes (exit 0)
- [x] `godot --headless --export-release "Web" build/index.html` passes (exit 0; pre-existing `icon.svg` warning unchanged)
- [ ] Played on the live site after merge
- [x] No regression in feel: movement script untouched