### PR TITLE
fix(hero): align PointLight2D with painted lantern + boost glow

### DIFF
--- a/scenes/Curiosity.tscn
+++ b/scenes/Curiosity.tscn
@@ -199,11 +199,11 @@ autoplay = "idle"
 shape = SubResource("RectangleShape2D_body")
 
 [node name="Lantern" type="PointLight2D" parent="."]
-position = Vector2(-128, 96)
-color = Color(1, 0.78, 0.42, 1)
-energy = 1.1
+position = Vector2(-144, 106)
+color = Color(1, 0.7, 0.3, 1)
+energy = 2.2
 texture = SubResource("GradientTexture2D_lantern")
-texture_scale = 1.6
+texture_scale = 2.8
 
 [node name="Camera" type="Camera2D" parent="."]
 position = Vector2(0, -160)


### PR DESCRIPTION
## Summary
- After PR #21 swapped in the hand-labeled animation set, the `PointLight2D` (tuned for the old sprite) ended up offset from the painted lantern, leaving it dark.
- Re-measured the lantern position by pixel-centroiding the warm metal across all 4 idle frames; result is consistent at sprite-offset (~-45, +33) from frame center → node-space (-144, +106) at scale 3.2.
- Boosted glow so the painted lantern reads as lit: energy 1.1→2.2, texture_scale 1.6→2.8, color (1, 0.78, 0.42)→(1.0, 0.7, 0.3).

## Notes
- Walk/run frames swing the painted lantern a few pixels relative to the static idle pose — accepted as realistic motion. PointLight2D position stays anchored to body, idle is ground truth.
- Script `_lantern_offset_x = abs(lantern.position.x)` at runtime, so the right-facing mirror picks up 144 automatically.

Closes #22

## Test plan
- [ ] CI: `godot --headless --import` clean
- [ ] CI: `godot --headless --export-release "Web"` clean
- [ ] Live build: painted lantern's interior visibly glows (light source blends into lantern, not floating beside it)
- [ ] Flip facing left↔right: lantern light follows the body to the new side
- [ ] Floor below Curiosity catches a warm pool of light

🤖 Generated with [Claude Code](https://claude.com/claude-code)