### PR TITLE
fix(hub): separate door interact key from jump — bind to Y

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -47,3 +47,9 @@ jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+interact={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":89,"physical_keycode":0,"key_label":0,"unicode":121,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+]
+}

--- a/scenes/TouchControls.tscn
+++ b/scenes/TouchControls.tscn
@@ -53,3 +53,20 @@ action = &"jump"
 position = Vector2(70, 70)
 color = Color(0.961, 0.722, 0.439, 0.95)
 polygon = PackedVector2Array(0, -18, -16, 12, 16, 12)
+
+[node name="InteractButton" type="TouchScreenButton" parent="."]
+texture_normal = SubResource("GradientTexture2D_glow")
+shape = SubResource("CircleShape2D_button")
+shape_visible = false
+action = &"interact"
+
+[node name="InteractLabel" type="Label" parent="InteractButton"]
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 140.0
+offset_bottom = 140.0
+theme_override_colors/font_color = Color(0.961, 0.722, 0.439, 0.95)
+theme_override_font_sizes/font_size = 64
+text = "Y"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scripts/Door.gd
+++ b/scripts/Door.gd
@@ -10,7 +10,7 @@ signal near_door(door)
 @export var door_id: String = ""
 @export_group("Prompt")
 @export var prompt_offset: Vector2 = Vector2(0, -120)
-@export var prompt_text: String = "↑ Enter"
+@export var prompt_text: String = "[Y] Enter"
 
 const _PROMPT_SIZE: Vector2 = Vector2(140, 30)
 const _PROMPT_COLOR: Color = Color(1.0, 0.93, 0.66, 0.95)
@@ -70,5 +70,5 @@ func _show_prompt(on: bool) -> void:
 func _process(_delta: float) -> void:
 	if not _player_inside:
 		return
-	if Input.is_action_just_pressed("jump") or Input.is_action_just_pressed("ui_up"):
+	if Input.is_action_just_pressed("interact"):
 		print("[Door] Entering ", target_realm, " via ", door_id)

--- a/scripts/TouchControls.gd
+++ b/scripts/TouchControls.gd
@@ -10,6 +10,7 @@ const BUTTON_GAP: float = 30.0
 @onready var _left: TouchScreenButton = $LeftButton
 @onready var _right: TouchScreenButton = $RightButton
 @onready var _jump: TouchScreenButton = $JumpButton
+@onready var _interact: TouchScreenButton = $InteractButton
 
 var _tweens: Dictionary = {}
 
@@ -21,6 +22,7 @@ func _ready() -> void:
 	_wire_button(_left)
 	_wire_button(_right)
 	_wire_button(_jump)
+	_wire_button(_interact)
 	get_viewport().size_changed.connect(_layout_buttons)
 	_layout_buttons()
 
@@ -54,7 +56,13 @@ func _fade(btn: TouchScreenButton, target_alpha: float) -> void:
 
 func _layout_buttons() -> void:
 	var size: Vector2 = get_viewport().get_visible_rect().size
-	var top_y: float = size.y - EDGE_PADDING - BUTTON_RADIUS * 2.0
-	_left.position = Vector2(EDGE_PADDING, top_y)
-	_right.position = Vector2(EDGE_PADDING + BUTTON_RADIUS * 2.0 + BUTTON_GAP, top_y)
-	_jump.position = Vector2(size.x - EDGE_PADDING - BUTTON_RADIUS * 2.0, top_y)
+	var button_size: float = BUTTON_RADIUS * 2.0
+	var bottom_y: float = size.y - EDGE_PADDING - button_size
+	var stacked_y: float = bottom_y - button_size - BUTTON_GAP
+	_left.position = Vector2(EDGE_PADDING, bottom_y)
+	_right.position = Vector2(EDGE_PADDING + button_size + BUTTON_GAP, bottom_y)
+	# Right cluster: jump on top, interact directly below so a thumb at rest
+	# sits on Enter and reaches up for jump.
+	var right_x: float = size.x - EDGE_PADDING - button_size
+	_jump.position = Vector2(right_x, stacked_y)
+	_interact.position = Vector2(right_x, bottom_y)


### PR DESCRIPTION
## Summary
- New ``interact`` action in ``project.godot`` bound to **Y** + gamepad button 0
- ``Door.gd`` listens for ``interact`` only (no longer fights with ``jump``); prompt now reads ``[Y] Enter``
- ``TouchControls`` gets a ``Y`` button stacked under Jump on the right cluster

## Test plan
- [ ] CI exports clean
- [ ] Walk under a door → prompt reads ``[Y] Enter``
- [ ] Press **Y** while overlapping a door → console logs entry, no jump
- [ ] Press **Up** while overlapping a door → Curiosity jumps, no door log
- [ ] On phone: tap the bottom-right **Y** button → entry fires

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)