### PR TITLE
fix(hub): central Y dispatch + visible door feedback

### DIFF
--- a/scenes/Hub.tscn
+++ b/scenes/Hub.tscn
@@ -4,7 +4,7 @@
 ; the original concept art is archived at assets/_reference/hub_concept.png
 ; for inspiration only. Parallax, particles, lore, and real door art are
 ; future waves.
-[gd_scene load_steps=18 format=3 uid="uid://b8h2u8b8b8h2u"]
+[gd_scene load_steps=19 format=3 uid="uid://b8h2u8b8b8h2u"]
 
 [ext_resource type="PackedScene" path="res://scenes/Curiosity.tscn" id="1_curiosity"]
 [ext_resource type="PackedScene" path="res://scenes/TouchControls.tscn" id="2_touch"]
@@ -12,6 +12,7 @@
 [ext_resource type="Texture2D" path="res://assets/scenes/hub/stone_floor.png" id="4_stone_floor"]
 [ext_resource type="Texture2D" path="res://assets/scenes/hub/door_arch.png" id="5_door_arch"]
 [ext_resource type="Texture2D" path="res://assets/effects/lantern_halo.png" id="6_halo"]
+[ext_resource type="Script" path="res://scripts/Hub.gd" id="7_hub"]
 
 [sub_resource type="Gradient" id="Gradient_sky"]
 offsets = PackedFloat32Array(0, 0.5, 1)
@@ -59,6 +60,7 @@ _data = {
 }
 
 [node name="Hub" type="Node2D"]
+script = ExtResource("7_hub")
 
 [node name="Sky" type="Sprite2D" parent="."]
 position = Vector2(640, 360)

--- a/scripts/Door.gd
+++ b/scripts/Door.gd
@@ -1,10 +1,13 @@
 extends Area2D
 
 # Reusable Hub door. Detects when Curiosity overlaps, shows a floating
-# "↑ Enter" prompt above the painted door, and on jump/up logs the
-# realm we'd transition to. Real scene transitions land in PR2.
+# "[Y] Enter" prompt above the painted door, and exposes trigger() for
+# Hub.gd to call when the central "interact" dispatch fires. Real scene
+# transitions land in a future PR; for now trigger() flashes the glow
+# and swaps the prompt so the player can SEE that Y registered.
 
 signal near_door(door)
+signal left_door(door)
 
 @export var target_realm: String = ""
 @export var door_id: String = ""
@@ -15,15 +18,37 @@ signal near_door(door)
 const _PROMPT_SIZE: Vector2 = Vector2(140, 30)
 const _PROMPT_COLOR: Color = Color(1.0, 0.93, 0.66, 0.95)
 const _PROMPT_OUTLINE: Color = Color(0, 0, 0, 0.85)
+const _GLOW_FLASH_ENERGY: float = 2.6
+const _GLOW_FLASH_TIME: float = 0.45
+const _PROMPT_FLASH_TEXT: String = "..."
+const _PROMPT_FLASH_TIME: float = 0.6
 
 var _player_inside: bool = false
 var _prompt: Label
+var _glow: PointLight2D
+var _glow_base_energy: float = 0.8
+var _flash_tween: Tween
 
 
 func _ready() -> void:
+	add_to_group("doors")
 	body_entered.connect(_on_body_entered)
 	body_exited.connect(_on_body_exited)
+	_glow = _find_glow()
+	if _glow:
+		_glow_base_energy = _glow.energy
 	_build_prompt()
+
+
+func _find_glow() -> PointLight2D:
+	# Glow lives under the sibling "Visual" node in the parent door root.
+	var parent_node: Node = get_parent()
+	if parent_node == null:
+		return null
+	var visual: Node = parent_node.get_node_or_null("Visual")
+	if visual == null:
+		return null
+	return visual.get_node_or_null("Glow") as PointLight2D
 
 
 func _build_prompt() -> void:
@@ -55,6 +80,7 @@ func _on_body_exited(body: Node) -> void:
 		return
 	_player_inside = false
 	_show_prompt(false)
+	left_door.emit(self)
 
 
 func _show_prompt(on: bool) -> void:
@@ -67,8 +93,23 @@ func _show_prompt(on: bool) -> void:
 		tween.tween_callback(func() -> void: _prompt.visible = false)
 
 
-func _process(_delta: float) -> void:
-	if not _player_inside:
-		return
-	if Input.is_action_just_pressed("interact"):
-		print("[Door] Entering ", target_realm, " via ", door_id)
+func trigger() -> void:
+	# Hub.gd calls this once per "interact" press while the player is in range.
+	# Print survives for editor/devtools observers; the visible flash is what
+	# the live-site player actually sees.
+	print("[Door] Entering ", target_realm, " via ", door_id)
+	_flash_feedback()
+
+
+func _flash_feedback() -> void:
+	if _flash_tween and _flash_tween.is_valid():
+		_flash_tween.kill()
+	_flash_tween = create_tween().set_parallel(true)
+	if _glow:
+		_glow.energy = _GLOW_FLASH_ENERGY
+		_flash_tween.tween_property(_glow, "energy", _glow_base_energy, _GLOW_FLASH_TIME) \
+			.set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+	if _prompt:
+		_prompt.text = _PROMPT_FLASH_TEXT
+		_flash_tween.tween_callback(func() -> void: _prompt.text = prompt_text) \
+			.set_delay(_PROMPT_FLASH_TIME)

--- a/scripts/Hub.gd
+++ b/scripts/Hub.gd
@@ -1,0 +1,47 @@
+extends Node2D
+
+# Hub controller. One node owns "did the player press interact?" so we
+# don't have N doors all polling Input each frame. Each Door joins the
+# "doors" group on _ready and emits near_door / left_door as the player
+# enters/exits its Area2D; Hub tracks the latest active door and, on
+# "interact", calls trigger() on it.
+#
+# The unconditional print is a deliberate breadcrumb for the live web
+# build — if it never appears in the JS console, the action isn't
+# reaching the game (focus / binding). If it prints with door=<none>,
+# the overlap signal is broken. If it prints with a door but nothing
+# visibly changes, trigger()'s feedback is the bug.
+
+var _current_door: Node = null
+
+
+func _ready() -> void:
+	for door in get_tree().get_nodes_in_group("doors"):
+		_connect_door(door)
+
+
+func _connect_door(door: Node) -> void:
+	if door.has_signal("near_door") and not door.near_door.is_connected(_on_door_entered):
+		door.near_door.connect(_on_door_entered)
+	if door.has_signal("left_door") and not door.left_door.is_connected(_on_door_exited):
+		door.left_door.connect(_on_door_exited)
+
+
+func _process(_delta: float) -> void:
+	if not Input.is_action_just_pressed("interact"):
+		return
+	var door_label: String = "<none>"
+	if _current_door and "door_id" in _current_door:
+		door_label = String(_current_door.door_id)
+	print("[Hub] interact pressed (current_door=", door_label, ")")
+	if _current_door and _current_door.has_method("trigger"):
+		_current_door.trigger()
+
+
+func _on_door_entered(door: Node) -> void:
+	_current_door = door
+
+
+func _on_door_exited(door: Node) -> void:
+	if _current_door == door:
+		_current_door = null

--- a/scripts/Hub.gd.uid
+++ b/scripts/Hub.gd.uid
@@ -1,0 +1,1 @@
+uid://budm2xbmsd8m3


### PR DESCRIPTION
## Summary
- Moves the `interact` (Y) handler out of every `Door._process` and into a single `Hub.gd` dispatcher attached to the Hub root. Doors join the `doors` group, expose `trigger()`, and emit `near_door` / `left_door`.
- Adds **visible** trigger feedback: the door's purple `PointLight2D` glow flashes up and the `[Y] Enter` prompt momentarily becomes `...` — so the live-site player can actually see Y register. Real scene transition is still a future PR.
- Keeps a one-line console breadcrumb on every press for future "did the input reach us?" debugging.

## Why
On the live web build the previous wiring only `print()`ed on Y. No on-screen response → looks broken to the player. Centralising the handler also removes a class of "three Area2Ds polling Input" flakiness from future reports.

## Test plan
- [x] `godot --headless --import` clean
- [x] `godot --headless --export-release "Web" build/index.html` clean (4.5MB pck, 38MB wasm)
- [ ] Live: walk under each of the 3 doors → `[Y] Enter` shows
- [ ] Live: press Y → glow pulses, prompt blips to `...` then back

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)