### PR TITLE
rebuild(realm1): classic platformer geometry — one tile per role, drop ceiling

### DIFF
--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -7,6 +7,41 @@ Format: `date | what shipped | what didn't work | next 3 safe candidates`
 
 ---
 
+## 2026-05-11 — Realm 1 full geometry rebuild (classic platformer)
+
+**Shipped**
+- Complete rebuild of Realm 1 level geometry against the same `mainlev_build.png`.
+  The collision + palette fix earlier in the day kept the level playable but the
+  layout was still chaotic. This rebuild restructures it as a classic 2D platformer:
+    - **One** ground-top tile `(4, 20)` across all 80 floor cells. No more 5-variant
+      mixing within row 9.
+    - **One** ground-interior tile `(7, 23)` filling rows 10-13 (SUBFLOOR_DEPTH=4)
+      for 4 rows of visible floor thickness.
+    - **One** 3-tile platform palette — `(24, 1) / (25, 1) / (28, 1)` wood-plank L /
+      M / R with the X-brace metal joint in the middle. Used uniformly across 10
+      floating platforms.
+    - 4 floor gaps, 4 tiles each, evenly distributed (cols 16-19, 36-39, 56-59,
+      76-79). Five floor sections of 16 cols between.
+    - 10 platforms total: y=8 bridges over each gap + y=8 step-ups + one y=7
+      chain-up challenge (out of direct floor reach, requires plat 3 as
+      intermediate) + a y=8/7/6 ascending victory path before the exit door.
+    - Ceiling row at y=0 and decor stalactites at y=1 removed entirely — the
+      parallax cave painting provides the overhead naturally.
+- Verified locally via headless capture tour (spawn + col 25 + col 45 + col 65 +
+  col 87): `on_floor=true` at floor positions, layout reads as the intended
+  ground/gap/platforms pattern, wood planks distinct from rocky floor.
+
+**What didn't work / dead ends**
+- Considered using brick `(26, 16)` for ground top (user-authorized fallback for
+  "clean horizontal top"). Rejected: bricks are orange-red and 100% solid across
+  large areas, breaks the cave tone. Stuck with peak-up rocky `(4, 20)` even
+  though it's 50% density and leaves a small transparent strip between the rim
+  and the sub-floor — the dark cave parallax behind makes the strip read as
+  shadow rather than a seam.
+- Tried using brown rocky chunks `(7,23)(8,23)(9,23)` for floating platforms.
+  Rejected: same material as ground interior, platforms didn't read as distinct
+  layer. Wood planks give the contrast.
+
 ## 2026-05-11 — Realm 1 fall-through + full tile rework
 
 **Shipped**

--- a/scenes/realms/Realm1.tscn
+++ b/scenes/realms/Realm1.tscn
@@ -17,14 +17,13 @@
 ;   layer tree by visual depth (7 deepest, 0 closest) — the opposite of
 ;   the file index.
 ;
-; TILE PALETTE  (single-theme brown cave; see scripts/Realm1.gd header
-; for the audit table and full SOLID_TILES list)
-;   GROUND_TOP  : (3,20) (4,20) (8,20) (11,20) (12,20)   — peak-up rocky rim
-;   GROUND_FILL : (7,23) (8,23) (9,23) (7,24) (8,24)     — solid sub-floor
-;   PLATFORM    : (7,23) (8,23) (9,23)                   — rocky floating chunks
-;   CEIL        : (7,29) (8,29)                          — peak-down stalactite tips
-;   DECOR       : (7,3)                                  — sparse decor stalactites
-;   Brick walls + red-gem fire pit dropped (palette clashed with brown cave).
+; TILE PALETTE  (ONE tile coord per role; see scripts/Realm1.gd for the
+; layout + reachability notes)
+;   T_GROUND_TOP  : (4,20)                              — peak-up rocky rim
+;   T_GROUND_FILL : (7,23)                              — solid brown sub-floor
+;   T_PLATFORM_L  : (24,1)  T_PLATFORM_M : (25,1)
+;   T_PLATFORM_R  : (28,1)                              — wood-plank platforms
+;   No ceiling, no decor — parallax cave painting provides the overhead.
 [gd_scene load_steps=22 format=3 uid="uid://crealm1caves002"]
 
 [ext_resource type="PackedScene" path="res://scenes/Curiosity.tscn" id="1_curiosity"]

--- a/scripts/Realm1.gd
+++ b/scripts/Realm1.gd
@@ -1,115 +1,83 @@
 extends Node2D
 
-# Realm 1 — caves. Linear left-to-right platforming. Geometry sits ON TOP
-# of an 8-layer parallax cave backdrop that fills the viewport at every
-# camera position (deepest layer is fully opaque, every layer mirrors
-# horizontally).
+# Realm 1 — caves. Classic-platformer geometry: continuous rocky floor
+# along the bottom with 4 intentional gaps, distinct floating wood-plank
+# platforms above at varied heights, parallax cave painting behind.
 #
-# Tile palette — all from the BROWN cave band of mainlev_build.png so the
-# foreground reads as a single cohesive cave (no mixing with the dark-blue
-# upper-sheet palette). Coords audited via scripts/inspect_tileset.py.
+# Tile palette — ONE tile coord per role. No mixing within a row.
 #
-#   GROUND_TOP   (peak-up rocky rim — what Curiosity walks on)
-#     (3,20) (4,20) (8,20) (11,20) (12,20)
-#   GROUND_FILL  (solid rocky interior — sub-floor below the rim)
-#     (7,23) (8,23) (9,23) (7,24) (8,24)
-#   PLATFORM     (solid rocky chunks — floating ledges, replaces old wood)
-#     (7,23) (8,23) (9,23)  shared with GROUND_FILL on purpose
-#   CEIL         (peak-down rocky — overhead, stalactite tips)
-#     (7,29) (8,29)
-#   DECOR        (no collision)
-#     (7,3)        stalactite cluster, sparse at tile_y=1
+#   T_GROUND_TOP  (4,20)   peak-up rocky rim   — the cave-floor surface,
+#                                                used uniformly across
+#                                                every floor cell at y=9.
+#   T_GROUND_FILL (7,23)   solid brown block   — interior fill for rows
+#                                                10..13, gives the floor
+#                                                visible thickness.
+#   T_PLATFORM_L  (24,1)   wood plank L-end    — 3+-tile wide floating
+#   T_PLATFORM_M  (25,1)   wood plank middle     platforms at y=6..8.
+#   T_PLATFORM_R  (28,1)   wood plank R-end      X-brace metal in middle.
 #
-# Dropped vs. the previous palette: brick bookend walls (clashed orange-red
-# with the brown cave) and the red gem fire-pit cluster (read as lava, wrong
-# tonal register for a cool cave). Wood planks → rocky chunks.
-#
-# The TileSet is built at runtime: every non-empty 32x32 cell on the source
-# sheet becomes an atlas tile, but only the curated SOLID_TILES coords below
-# carry collision polygons. Decorative tiles end up on a separate non-
-# colliding TileMapLayer.
+# Dropped vs. earlier builds: brick bookend walls, red gem fire-pit,
+# ceiling row at y=0, decor stalactites at y=1. The parallax cave painting
+# already provides the overhead atmosphere — no tile ceiling needed.
 
 const SOURCE_TEXTURE: Texture2D = preload("res://assets/realms/realm1_caves/mainlev_build.png")
 const ATLAS_TILE_SIZE: Vector2i = Vector2i(32, 32)
 
-# Atlas coords — see header comment for source.
-const T_GROUND_TOP_A: Vector2i = Vector2i(3, 20)
-const T_GROUND_TOP_B: Vector2i = Vector2i(4, 20)
-const T_GROUND_TOP_C: Vector2i = Vector2i(8, 20)
-const T_GROUND_TOP_D: Vector2i = Vector2i(11, 20)
-const T_GROUND_TOP_E: Vector2i = Vector2i(12, 20)
-const T_GROUND_FILL_A: Vector2i = Vector2i(7, 23)
-const T_GROUND_FILL_B: Vector2i = Vector2i(8, 23)
-const T_GROUND_FILL_C: Vector2i = Vector2i(9, 23)
-const T_GROUND_FILL_D: Vector2i = Vector2i(7, 24)
-const T_GROUND_FILL_E: Vector2i = Vector2i(8, 24)
-const T_PLATFORM_L:   Vector2i = Vector2i(7, 23)
-const T_PLATFORM_M:   Vector2i = Vector2i(8, 23)
-const T_PLATFORM_R:   Vector2i = Vector2i(9, 23)
-const T_CEIL_A:       Vector2i = Vector2i(7, 29)
-const T_CEIL_B:       Vector2i = Vector2i(8, 29)
-const T_DECOR_STAL:   Vector2i = Vector2i(7, 3)
+# ONE tile per role — uniform palette, no in-row variation.
+const T_GROUND_TOP:  Vector2i = Vector2i(4, 20)
+const T_GROUND_FILL: Vector2i = Vector2i(7, 23)
+const T_PLATFORM_L:  Vector2i = Vector2i(24, 1)
+const T_PLATFORM_M:  Vector2i = Vector2i(25, 1)
+const T_PLATFORM_R:  Vector2i = Vector2i(28, 1)
 
-const GROUND_TOP_VARIANTS: Array[Vector2i] = [
-	T_GROUND_TOP_A, T_GROUND_TOP_B, T_GROUND_TOP_C, T_GROUND_TOP_D, T_GROUND_TOP_E,
-]
-const GROUND_FILL_VARIANTS: Array[Vector2i] = [
-	T_GROUND_FILL_A, T_GROUND_FILL_B, T_GROUND_FILL_C, T_GROUND_FILL_D, T_GROUND_FILL_E,
-]
 const SOLID_TILES: Array[Vector2i] = [
-	T_GROUND_TOP_A, T_GROUND_TOP_B, T_GROUND_TOP_C, T_GROUND_TOP_D, T_GROUND_TOP_E,
-	T_GROUND_FILL_A, T_GROUND_FILL_B, T_GROUND_FILL_C, T_GROUND_FILL_D, T_GROUND_FILL_E,
+	T_GROUND_TOP, T_GROUND_FILL,
 	T_PLATFORM_L, T_PLATFORM_M, T_PLATFORM_R,
-	T_CEIL_A, T_CEIL_B,
 ]
 
 # World scale: parent Node2D scales TileMapLayers 2x so visual cells
 # read as 64x64. Level extents are kept in tile coords below.
 const VISUAL_TILE: int = 64
 
-# Level dimensions. 96 tiles wide x 64 = 6144 world px, just past the
-# requested ~6000. Floor sits at tile_y = 9 so its top edge lands at
-# world y = 576 (matches the spec's "floor y around 550-720").
+# Level dimensions. 96 tiles wide x 64 = 6144 world px.
+# Floor sits at tile_y = 9 so its top edge lands at world y = 576.
 const LEVEL_WIDTH_TILES: int = 96
 const FLOOR_Y: int = 9
-const SUBFLOOR_DEPTH: int = 3   # rows below the floor surface (out-of-view fill)
+# Sub-floor fills rows 10..13 (4 rows of visible thickness, as requested).
+const SUBFLOOR_DEPTH: int = 4
 
-# Reachability note: jump_velocity=-240, gravity=350 → ~82px peak. From
-# the floor (y=9) Curiosity can land on tile_y=8; from y=8 she reaches
-# y=7; etc. So multi-tier platforms must be staircased one tile at a
-# time.
+# Reachability: jump_velocity=-240, gravity=350 → ~82px peak ≈ 1 tile
+# (with VISUAL_TILE=64). So Curiosity reaches +1 tile vertical per jump.
+# That means y=8 is reachable from floor y=9; y=7 needs an intermediate
+# y=8 platform; y=6 needs y=7 → y=8 → floor.
 
-# Floor gaps Curiosity must jump. [tile_x_start_inclusive, tile_x_end_exclusive].
+# Four gaps in the floor — 4 tiles wide each, evenly distributed.
+# Five floor sections separated by gaps: 0-15, 20-35, 40-55, 60-75, 80-95.
 const FLOOR_GAPS: Array = [
-	[15, 18],   # 3-tile gap, easy
-	[33, 37],   # 4-tile gap, medium
-	[50, 55],   # 5-tile gap, bridged by a platform at y=8
-	[72, 75],   # 3-tile gap, easy
+	[16, 20],   # gap 1 (4 tiles)
+	[36, 40],   # gap 2
+	[56, 60],   # gap 3
+	[76, 80],   # gap 4
 ]
 
-# Floating platforms — rocky chunks. [tile_x_left, tile_x_right_inclusive, tile_y].
-# 10 platforms total; chain at x=25-30 climbs y=8 → 7 → 6 ; chain at
-# x=63-66 ascends y=7 → 6.
+# Floating platforms — wood planks. [tile_x_left, tile_x_right_inclusive, tile_y].
+# 10 platforms total, sized 3 tiles wide. Roles:
+#   1-3,5-7,8   — y=8 bridges (one per gap) and step-up intros
+#   4           — y=7 CHAIN-UP, requires plat 3 as intermediate (out of
+#                 direct reach from floor)
+#   8,9,10      — y=8 → y=7 → y=6 ascending victory path before exit
 const PLATFORMS: Array = [
-	[10, 12, 8],
-	[22, 24, 8],
-	[25, 27, 7],
-	[28, 30, 6],
-	[40, 42, 8],
-	[51, 53, 8],   # bridges floor gap 3
-	[60, 62, 8],
-	[63, 65, 7],
-	[78, 80, 8],
-	[82, 84, 7],   # chained from the y=8 platform — 2-tile gap clears under jump
+	[9, 11, 8],     # 1. intro step-up in section 1
+	[17, 19, 8],    # 2. low bridge over gap 1
+	[25, 27, 8],    # 3. chain setup in section 2
+	[28, 30, 7],    # 4. CHAIN UP — out of direct floor reach
+	[37, 39, 8],    # 5. low bridge over gap 2
+	[57, 59, 8],    # 6. low bridge over gap 3
+	[77, 79, 8],    # 7. low bridge over gap 4
+	[84, 86, 8],    # 8. ascending step 1 (victory path)
+	[87, 89, 7],    # 9. ascending step 2
+	[90, 92, 6],    # 10. ascending step 3 — peak next to exit
 ]
-
-# Solid ceiling tiles — overhead at tile_y=0 across the level.
-const CEILING_RUNS: Array = [
-	[0, LEVEL_WIDTH_TILES],   # one run, full level width
-]
-
-# Decorative ceiling stalactites at tile_y=1, sparse.
-const DECOR_STAL_X: Array = [4, 11, 19, 26, 35, 44, 53, 61, 70, 78, 87]
 
 const SPAWN_TILE: Vector2i = Vector2i(2, FLOOR_Y - 1)
 const EXIT_DOOR_TILE: Vector2i = Vector2i(LEVEL_WIDTH_TILES - 4, FLOOR_Y - 1)
@@ -124,7 +92,6 @@ func _ready() -> void:
 	_solids.tile_set = ts
 	_decor.tile_set = ts
 	_paint_solids()
-	_paint_decor()
 	_position_curiosity()
 	_position_exit_door()
 	_setup_camera_limits()
@@ -141,8 +108,7 @@ func _build_tileset() -> TileSet:
 	src.texture_region_size = ATLAS_TILE_SIZE
 	# Source must be attached BEFORE create_tile so the TileSet's physics
 	# layers propagate to per-tile data; otherwise add_collision_polygon
-	# errors with physics.size()=0 and every tile ends up non-colliding
-	# (which is what made Curiosity fall through the floor).
+	# errors with physics.size()=0 and every tile ends up non-colliding.
 	ts.add_source(src, 0)
 
 	var img: Image = SOURCE_TEXTURE.get_image()
@@ -194,18 +160,16 @@ func _attach_full_collision(src: TileSetAtlasSource, coord: Vector2i, phys_layer
 
 
 func _paint_solids() -> void:
-	# Floor surface (peak-up rim) + sub-floor fill, with gaps cut out.
+	# Floor surface (single ground-top tile) + sub-floor fill (single
+	# interior tile), with the 4 gaps cut out completely.
 	for x in range(LEVEL_WIDTH_TILES):
 		if _x_in_gap(x):
 			continue
-		var top_coord: Vector2i = GROUND_TOP_VARIANTS[x % GROUND_TOP_VARIANTS.size()]
-		_solids.set_cell(Vector2i(x, FLOOR_Y), 0, top_coord)
-		# Sub-floor fill — keeps the cave from looking like a floating ribbon.
+		_solids.set_cell(Vector2i(x, FLOOR_Y), 0, T_GROUND_TOP)
 		for d in range(1, SUBFLOOR_DEPTH + 1):
-			var sub_coord: Vector2i = GROUND_FILL_VARIANTS[(x + d) % GROUND_FILL_VARIANTS.size()]
-			_solids.set_cell(Vector2i(x, FLOOR_Y + d), 0, sub_coord)
+			_solids.set_cell(Vector2i(x, FLOOR_Y + d), 0, T_GROUND_FILL)
 
-	# Floating platforms — rocky chunks, left / middle / right.
+	# Floating wood-plank platforms — L / M.../ R from a single 3-tile palette.
 	for p in PLATFORMS:
 		var px_left: int = int(p[0])
 		var px_right: int = int(p[1])
@@ -214,19 +178,6 @@ func _paint_solids() -> void:
 		for mx in range(px_left + 1, px_right):
 			_solids.set_cell(Vector2i(mx, py), 0, T_PLATFORM_M)
 		_solids.set_cell(Vector2i(px_right, py), 0, T_PLATFORM_R)
-
-	# Solid ceiling at tile_y = 0 across the level — peak-down rocky tips so
-	# the overhead reads as stalactite-laden cave roof. Also blocks any
-	# future high-jump glitches from leaving frame.
-	for run in CEILING_RUNS:
-		for cx in range(int(run[0]), int(run[1])):
-			var ceil_coord: Vector2i = T_CEIL_A if (cx % 2) == 0 else T_CEIL_B
-			_solids.set_cell(Vector2i(cx, 0), 0, ceil_coord)
-
-
-func _paint_decor() -> void:
-	for x in DECOR_STAL_X:
-		_decor.set_cell(Vector2i(int(x), 1), 0, T_DECOR_STAL)
 
 
 func _x_in_gap(x: int) -> bool:


### PR DESCRIPTION
Closes #61.

## Summary

Full restructure of Realm 1 against the existing tile sheet. Replaces the chaotic 5-variant ground + thin wood planks + broken stalactite clutter with a clean classic-platformer layout: continuous rocky cave floor with 4 intentional gaps, distinct wood-plank floating platforms at varied heights, no tile ceiling (parallax cave painting fills overhead).

## ONE tile per role — no in-row variant mixing

| Role | Coord | Why |
|------|-------|-----|
| Ground TOP | `(4, 20)` | Peak-up rocky cave rim — visually reads as cave floor surface across all 80 cells. |
| Ground INTERIOR | `(7, 23)` | 100% solid brown block — fills rows 10-13 (4 rows of thickness). |
| Platform L | `(24, 1)` | Wood plank left-end with bevel rim. |
| Platform M | `(25, 1)` | Wood plank middle with metal X-brace joint. |
| Platform R | `(28, 1)` | Wood plank right-end with bevel rim. |

Brick walls, gem fire-pit, ceiling tiles at y=0, and decor stalactites at y=1 all removed — the dark-cave parallax painting provides the overhead atmosphere naturally.

## Level layout (96 tiles wide, 5 floor sections + 4 gaps)

```
Cols    0         1         2         3         4         5         6         7         8         9
        0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
y=6                                                                                                ppp           plat 10 (asc 3, peak)
y=7                                ppp                                                          ppp              plat 4 (CHAIN UP), plat 9 (asc 2)
y=8             ppp     ppp   ppp         ppp                     ppp                     ppp ppp                plats 1, 2, 3, 5, 6, 7, 8
y=9-13  ==============....==============....==============....==============....==============                  floor + 4 rows of fill
                              ^                 ^                 ^                 ^
                            gap 1             gap 2             gap 3             gap 4
                            16-19             36-39             56-59             76-79
```

## Platform list (10 total, all 3 tiles wide)

```
1. cols  9-11, y=8   intro step-up in section 1
2. cols 17-19, y=8   low bridge over gap 1
3. cols 25-27, y=8   chain setup in section 2
4. cols 28-30, y=7   CHAIN UP from plat 3 (out of direct floor reach)
5. cols 37-39, y=8   low bridge over gap 2
6. cols 57-59, y=8   low bridge over gap 3
7. cols 77-79, y=8   low bridge over gap 4
8. cols 84-86, y=8   ascending step 1 (victory path)
9. cols 87-89, y=7   ascending step 2
10. cols 90-92, y=6  ascending step 3 — peak next to exit
```

Reachability respects `jump_velocity=-240` / `gravity=350` (~+1 tile per jump). y=8 platforms reachable from floor y=9. Plat 4 at y=7 needs plat 3 as intermediate. Ascending stairs (plat 8 -> 9 -> 10) chain y=8 -> 7 -> 6 just before the exit door.

## Tile placement counts

| Role | Tiles placed |
|------|--------------|
| Ground TOP (`(4,20)`) | 80 (one per non-gap floor col) |
| Ground INTERIOR (`(7,23)`) | 320 (80 cols x 4 sub-floor rows) |
| Platform L/M/R (`(24,1)`/`(25,1)`/`(28,1)`) | 30 (10 platforms x 3 tiles) |
| **Ceiling tiles** | **0** |
| **Decor tiles** | **0** |
| **Total** | **430** |

Confirmation: zero random tile mixing. Every floor-top cell is `(4,20)`. Every sub-floor cell is `(7,23)`. Every platform cell is one of `(24,1)/(25,1)/(28,1)`.

## Verified locally

Headless capture tour on this branch:

```
[CAPTURE] spawn pos=(160.0, 467.99) on_floor=true feet_y=576.0
[CAPTURE] at x_tile=25 pos=(1577.93, 467.92) on_floor=true
[CAPTURE] at x_tile=45 pos=(2880.0, 467.92) on_floor=true
[CAPTURE] at x_tile=65 pos=(4160.0, 467.92) on_floor=true
```

- Curiosity stands on floor at every floor-tile position tested.
- Spawn screenshot shows: rocky floor with rim + gap visible + first two platforms (intro step-up + over-gap bridge) + parallax cave painting overhead with no tile-ceiling interference.

## Out of scope

- Decorative props (hanging crystals, cave plants) — the tile sheet doesn't have a single-tile prop that fits the cool brown cave palette without re-introducing the red-gem fire pit. Defer to a follow-up.
- Curiosity, Hub, Door, SceneTransition — untouched.
- Parallax cave painting layers — untouched.