### PR TITLE
feat(realm1): rebuild as Crimson Hollow per chunk spec

### DIFF
--- a/scenes/realms/Realm1.tscn
+++ b/scenes/realms/Realm1.tscn
@@ -1,30 +1,28 @@
-; Realm 1 — caves. The cave painting fills the viewport at every camera
-; position; the tile geometry lives ON TOP of it as the actual playable
-; level (Curiosity walks/jumps on tiles, with the parallax visible behind
-; her at all times).
+; Realm 1 — "The Crimson Hollow".
+;
+; Geometry is built in scripts/Realm1.gd. This scene wires up the
+; structural pieces only: parallax, lighting, tile layers, the hero
+; instance, the exit door, and touch controls.
 ;
 ; PARALLAX
-;   8 layers stacked deepest-first. Each Sprite2D is scaled 3.334x so the
-;   384x216 source fills the 1280x720 viewport, with motion_mirroring set
-;   to (1280, 0) so the layer tiles horizontally across the level. The
-;   deepest layer (7.png) is fully opaque so no transparent gap exposes
-;   the project background colour. motion_scale.y = 1 — vertical follows
-;   camera, which combined with limit_top=0 / limit_bottom=720 keeps the
-;   parallax exactly aligned to viewport top/bottom.
+;   Eight layers of the cave painting. Each Sprite2D is scaled 3.334x so
+;   the 384x216 source fills the 1280x720 viewport. motion_mirroring.x
+;   tiles each layer horizontally across the level.
 ;
-;   Note: the asset pack numbers files such that 0.png is the most-detailed
-;   foreground layer and 7.png is the flat backdrop tint. We stack the
-;   layer tree by visual depth (7 deepest, 0 closest) — the opposite of
-;   the file index.
+;   motion_scale.y = 0 on every layer — the parallax is viewport-locked
+;   vertically. This is the key fix for the new 1920-tall world: with a
+;   camera that traverses y=360..1560 (top-of-shaft to bottom-of-pit),
+;   the parallax stays glued to the viewport instead of falling off the
+;   bottom of the artwork. No grey gap at any camera position.
 ;
-; TILE PALETTE  (ONE tile coord per role; see scripts/Realm1.gd for the
-; layout + reachability notes)
-;   T_GROUND_TOP  : (4,20)                              — peak-up rocky rim
-;   T_GROUND_FILL : (7,23)                              — solid brown sub-floor
-;   T_PLATFORM_L  : (24,1)  T_PLATFORM_M : (25,1)
-;   T_PLATFORM_R  : (28,1)                              — wood-plank platforms
-;   No ceiling, no decor — parallax cave painting provides the overhead.
-[gd_scene load_steps=22 format=3 uid="uid://crealm1caves002"]
+;   Asset numbering: 0.png is the closest detail layer, 7.png is the flat
+;   backdrop tint. The tree is stacked by visual depth (L7 deepest first).
+;
+; TILE LAYERS
+;   * Solids       — colliding ground, walls, crystal blocks/surrounds
+;   * Stalactites  — decorative-only, NO collision
+
+[gd_scene load_steps=22 format=3 uid="uid://crealm1caves003"]
 
 [ext_resource type="PackedScene" path="res://scenes/Curiosity.tscn" id="1_curiosity"]
 [ext_resource type="PackedScene" path="res://scenes/TouchControls.tscn" id="2_touch"]
@@ -50,7 +48,7 @@ script = ExtResource("3_realm1")
 [node name="ParallaxBackground" type="ParallaxBackground" parent="."]
 
 [node name="L7" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.05, 1)
+motion_scale = Vector2(0.05, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L7"]
@@ -60,7 +58,7 @@ texture = ExtResource("12_p7")
 scale = Vector2(3.334, 3.334)
 
 [node name="L6" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.1, 1)
+motion_scale = Vector2(0.1, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L6"]
@@ -70,7 +68,7 @@ texture = ExtResource("11_p6")
 scale = Vector2(3.334, 3.334)
 
 [node name="L5" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.2, 1)
+motion_scale = Vector2(0.2, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L5"]
@@ -80,7 +78,7 @@ texture = ExtResource("10_p5")
 scale = Vector2(3.334, 3.334)
 
 [node name="L4" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.35, 1)
+motion_scale = Vector2(0.35, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L4"]
@@ -90,7 +88,7 @@ texture = ExtResource("9_p4")
 scale = Vector2(3.334, 3.334)
 
 [node name="L3" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.5, 1)
+motion_scale = Vector2(0.5, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L3"]
@@ -100,7 +98,7 @@ texture = ExtResource("8_p3")
 scale = Vector2(3.334, 3.334)
 
 [node name="L2" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.65, 1)
+motion_scale = Vector2(0.65, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L2"]
@@ -110,7 +108,7 @@ texture = ExtResource("7_p2")
 scale = Vector2(3.334, 3.334)
 
 [node name="L1" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.8, 1)
+motion_scale = Vector2(0.8, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L1"]
@@ -120,7 +118,7 @@ texture = ExtResource("6_p1")
 scale = Vector2(3.334, 3.334)
 
 [node name="L0" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_scale = Vector2(0.95, 1)
+motion_scale = Vector2(0.95, 0)
 motion_mirroring = Vector2(1280, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/L0"]
@@ -137,14 +135,14 @@ scale = Vector2(2, 2)
 
 [node name="Solids" type="TileMapLayer" parent="World"]
 
-[node name="Decor" type="TileMapLayer" parent="World"]
+[node name="Stalactites" type="TileMapLayer" parent="World"]
 
 [node name="Curiosity" parent="." instance=ExtResource("1_curiosity")]
-position = Vector2(160, 468)
+position = Vector2(160, 1300)
 scale = Vector2(0.5, 0.5)
 
 [node name="ExitDoor" type="Node2D" parent="."]
-position = Vector2(5920, 236)
+position = Vector2(7520, 544)
 
 [node name="Visual" type="Node2D" parent="ExitDoor"]
 
@@ -165,7 +163,6 @@ prompt_offset = Vector2(0, -110)
 prompt_text = "[Y] Return"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ExitDoor/DoorArea"]
-position = Vector2(0, 125)
 shape = SubResource("RectangleShape2D_exitdoor")
 
 [node name="TouchControls" parent="." instance=ExtResource("2_touch")]

--- a/scripts/Realm1.gd
+++ b/scripts/Realm1.gd
@@ -1,102 +1,89 @@
 extends Node2D
 
-# Realm 1 — caves. Classic-platformer geometry: continuous rocky floor
-# along the bottom with 4 intentional gaps, distinct floating wood-plank
-# platforms above at varied heights, parallax cave painting behind.
+# Realm 1 — "The Crimson Hollow".
 #
-# Tile palette — ONE tile coord per role. No mixing within a row.
+# 120-wide x 30-tall tilemap, 2x visual scale (each tile renders 64x64 px).
+# World extents: 7680 x 1920 px.
 #
-#   T_GROUND_TOP  (4,20)   peak-up rocky rim   — the cave-floor surface,
-#                                                used uniformly across
-#                                                every floor cell at y=9.
-#   T_GROUND_FILL (7,23)   solid brown block   — interior fill for rows
-#                                                10..13, gives the floor
-#                                                visible thickness.
-#   T_PLATFORM_L  (24,1)   wood plank L-end    — 3+-tile wide floating
-#   T_PLATFORM_M  (25,1)   wood plank middle     platforms at y=6..8.
-#   T_PLATFORM_R  (28,1)   wood plank R-end      X-brace metal in middle.
+# Five chunks of mechanical placement (no creative deviation):
+#   1. Intro Cave            (x=  0..24)  flat floor at y=22 + 2 hop platforms
+#   2. Broken Cavern         (x= 25..49)  floor with 3 gaps + bridge platforms
+#   3. Red Crystal Chamber   (x= 50..74)  big chasm, crystal platforms + pillars
+#   4. Vertical Climb        (x= 75..99)  walled shaft with climbing staircase
+#   5. Final Core Chamber    (x=100..119) high floor at y=9, exit door + pillar
 #
-# Dropped vs. earlier builds: brick bookend walls, red gem fire-pit,
-# ceiling row at y=0, decor stalactites at y=1. The parallax cave painting
-# already provides the overhead atmosphere — no tile ceiling needed.
+# Two TileMapLayers:
+#   * Solids — colliding. Ground tops/fills, edge walls, crystal blocks/surrounds.
+#   * Stalactites — decorative only, NO collision.
+#
+# Tile palette is mixed within each role for visual variety; selection is
+# deterministic from a seeded RNG so the level renders identically every run.
 
 const SOURCE_TEXTURE: Texture2D = preload("res://assets/realms/realm1_caves/mainlev_build.png")
 const ATLAS_TILE_SIZE: Vector2i = Vector2i(32, 32)
 
-# ONE tile per role — uniform palette, no in-row variation.
-const T_GROUND_TOP:  Vector2i = Vector2i(4, 20)
-const T_GROUND_FILL: Vector2i = Vector2i(7, 23)
-const T_PLATFORM_L:  Vector2i = Vector2i(24, 1)
-const T_PLATFORM_M:  Vector2i = Vector2i(25, 1)
-const T_PLATFORM_R:  Vector2i = Vector2i(28, 1)
+# ─── palette ─────────────────────────────────────────────────────────────
+const GROUND_TOP_VARIANTS: Array[Vector2i] = [
+	Vector2i(3, 20), Vector2i(5, 20), Vector2i(7, 20),
+	Vector2i(10, 20), Vector2i(12, 20),
+]
+const GROUND_FILL_VARIANTS: Array[Vector2i] = [
+	Vector2i(7, 23), Vector2i(8, 23), Vector2i(9, 23),
+	Vector2i(7, 24), Vector2i(8, 24), Vector2i(9, 24),
+	Vector2i(7, 25), Vector2i(8, 25),
+]
+const LEFT_EDGE_VARIANTS: Array[Vector2i] = [Vector2i(1, 20), Vector2i(1, 22)]
+const RIGHT_EDGE_VARIANTS: Array[Vector2i] = [Vector2i(13, 20), Vector2i(13, 22)]
+const STALACTITE_VARIANTS: Array[Vector2i] = [Vector2i(3, 18), Vector2i(14, 18)]
+const CRYSTAL_BLOCK: Vector2i = Vector2i(20, 25)
+const CRYSTAL_SURROUND: Vector2i = Vector2i(20, 24)
 
+# Every coord that lives in the colliding Solids layer.
 const SOLID_TILES: Array[Vector2i] = [
-	T_GROUND_TOP, T_GROUND_FILL,
-	T_PLATFORM_L, T_PLATFORM_M, T_PLATFORM_R,
+	Vector2i(3, 20), Vector2i(5, 20), Vector2i(7, 20),
+	Vector2i(10, 20), Vector2i(12, 20),
+	Vector2i(7, 23), Vector2i(8, 23), Vector2i(9, 23),
+	Vector2i(7, 24), Vector2i(8, 24), Vector2i(9, 24),
+	Vector2i(7, 25), Vector2i(8, 25),
+	Vector2i(1, 20), Vector2i(1, 22),
+	Vector2i(13, 20), Vector2i(13, 22),
+	Vector2i(20, 24), Vector2i(20, 25),
 ]
 
-# World scale: parent Node2D scales TileMapLayers 2x so visual cells
-# read as 64x64. Level extents are kept in tile coords below.
+# ─── geometry ────────────────────────────────────────────────────────────
 const VISUAL_TILE: int = 64
+const LEVEL_WIDTH_TILES: int = 120
+const LEVEL_HEIGHT_TILES: int = 30
+const MAP_BOTTOM_Y: int = 29  # last fill row before the map edge
+const RNG_SEED: int = 0x6c6f7265 # "lore" — deterministic variant picking
 
-# Level dimensions. 96 tiles wide x 64 = 6144 world px.
-# Floor sits at tile_y = 9 so its top edge lands at world y = 576.
-const LEVEL_WIDTH_TILES: int = 96
-const FLOOR_Y: int = 9
-# Sub-floor fills rows 10..13 (4 rows of visible thickness, as requested).
-const SUBFLOOR_DEPTH: int = 4
-
-# Reachability: jump_velocity=-240, gravity=350 → ~82px peak ≈ 1 tile
-# (with VISUAL_TILE=64). So Curiosity reaches +1 tile vertical per jump.
-# That means y=8 is reachable from floor y=9; y=7 needs an intermediate
-# y=8 platform; y=6 needs y=7 → y=8 → floor.
-
-# Four gaps in the floor — 4 tiles wide each, evenly distributed.
-# Five floor sections separated by gaps: 0-15, 20-35, 40-55, 60-75, 80-95.
-const FLOOR_GAPS: Array = [
-	[16, 20],   # gap 1 (4 tiles)
-	[36, 40],   # gap 2
-	[56, 60],   # gap 3
-	[76, 80],   # gap 4
-]
-
-# Floating platforms — wood planks. [tile_x_left, tile_x_right_inclusive, tile_y].
-# 10 platforms total, sized 3 tiles wide. Roles:
-#   1-3,5-7,8   — y=8 bridges (one per gap) and step-up intros
-#   4           — y=7 CHAIN-UP, requires plat 3 as intermediate (out of
-#                 direct reach from floor)
-#   8,9,10      — y=8 → y=7 → y=6 ascending victory path before exit
-const PLATFORMS: Array = [
-	[9, 11, 8],     # 1. intro step-up in section 1
-	[17, 19, 8],    # 2. low bridge over gap 1
-	[25, 27, 8],    # 3. chain setup in section 2
-	[28, 30, 7],    # 4. CHAIN UP — out of direct floor reach
-	[37, 39, 8],    # 5. low bridge over gap 2
-	[57, 59, 8],    # 6. low bridge over gap 3
-	[77, 79, 8],    # 7. low bridge over gap 4
-	[84, 86, 8],    # 8. ascending step 1 (victory path)
-	[87, 89, 7],    # 9. ascending step 2
-	[90, 92, 6],    # 10. ascending step 3 — peak next to exit
-]
-
-const SPAWN_TILE: Vector2i = Vector2i(2, FLOOR_Y - 1)
-const EXIT_DOOR_TILE: Vector2i = Vector2i(LEVEL_WIDTH_TILES - 4, FLOOR_Y - 1)
+const SPAWN_TILE: Vector2i = Vector2i(2, 20)
+const EXIT_DOOR_TILE: Vector2i = Vector2i(117, 8)
 
 @onready var _solids: TileMapLayer = $World/Solids
-@onready var _decor: TileMapLayer = $World/Decor
+@onready var _stalactites: TileMapLayer = $World/Stalactites
 @onready var _curiosity: CharacterBody2D = $Curiosity
+
+var _rng: RandomNumberGenerator
 
 
 func _ready() -> void:
+	_rng = RandomNumberGenerator.new()
+	_rng.seed = RNG_SEED
 	var ts: TileSet = _build_tileset()
 	_solids.tile_set = ts
-	_decor.tile_set = ts
-	_paint_solids()
+	_stalactites.tile_set = ts
+	_paint_chunk_1_intro_cave()
+	_paint_chunk_2_broken_cavern()
+	_paint_chunk_3_crystal_chamber()
+	_paint_chunk_4_vertical_climb()
+	_paint_chunk_5_final_core()
 	_position_curiosity()
 	_position_exit_door()
 	_setup_camera_limits()
 
 
+# ─── tileset construction ────────────────────────────────────────────────
 func _build_tileset() -> TileSet:
 	var ts: TileSet = TileSet.new()
 	ts.tile_size = ATLAS_TILE_SIZE
@@ -106,8 +93,8 @@ func _build_tileset() -> TileSet:
 	var src: TileSetAtlasSource = TileSetAtlasSource.new()
 	src.texture = SOURCE_TEXTURE
 	src.texture_region_size = ATLAS_TILE_SIZE
-	# Source must be attached BEFORE create_tile so the TileSet's physics
-	# layers propagate to per-tile data; otherwise add_collision_polygon
+	# Source must be attached BEFORE create_tile so the physics layer
+	# propagates to per-tile data; otherwise add_collision_polygon
 	# errors with physics.size()=0 and every tile ends up non-colliding.
 	ts.add_source(src, 0)
 
@@ -125,12 +112,10 @@ func _build_tileset() -> TileSet:
 			src.create_tile(coord)
 			if SOLID_TILES.has(coord):
 				_attach_full_collision(src, coord, phys_layer_id)
-
 	return ts
 
 
 func _cell_is_filled(img: Image, coord: Vector2i) -> bool:
-	# 5% non-transparent coverage is enough to count as a populated cell.
 	var threshold: int = int(ATLAS_TILE_SIZE.x * ATLAS_TILE_SIZE.y * 0.05)
 	var nonempty: int = 0
 	var ax: int = coord.x * ATLAS_TILE_SIZE.x
@@ -159,37 +144,146 @@ func _attach_full_collision(src: TileSetAtlasSource, coord: Vector2i, phys_layer
 	data.set_collision_polygon_points(phys_layer, 0, poly)
 
 
-func _paint_solids() -> void:
-	# Floor surface (single ground-top tile) + sub-floor fill (single
-	# interior tile), with the 4 gaps cut out completely.
-	for x in range(LEVEL_WIDTH_TILES):
-		if _x_in_gap(x):
+# ─── chunk painters ──────────────────────────────────────────────────────
+# All coordinates and ranges below are LITERAL from the design spec.
+
+func _paint_chunk_1_intro_cave() -> void:
+	# Continuous floor at y=22 from x=0..24.
+	_paint_floor_row(0, 24, 22)
+	# Floating platform (x=10..13, y=18) — 4 wide.
+	_paint_ground_strip(10, 13, 18)
+	# Floating platform (x=18..20, y=17) — 3 wide.
+	_paint_ground_strip(18, 20, 17)
+	# Decorative stalactites.
+	_paint_stalactite(5, 12)
+	_paint_stalactite(8, 12)
+	_paint_stalactite(15, 12)
+	_paint_stalactite(22, 12)
+
+
+func _paint_chunk_2_broken_cavern() -> void:
+	# Floor at y=22 from x=25..49 with gaps at 28..31, 37..41, 45..47.
+	var gaps: Array = [[28, 31], [37, 41], [45, 47]]
+	for x in range(25, 50):
+		if _x_in_any_range(x, gaps):
 			continue
-		_solids.set_cell(Vector2i(x, FLOOR_Y), 0, T_GROUND_TOP)
-		for d in range(1, SUBFLOOR_DEPTH + 1):
-			_solids.set_cell(Vector2i(x, FLOOR_Y + d), 0, T_GROUND_FILL)
-
-	# Floating wood-plank platforms — L / M.../ R from a single 3-tile palette.
-	for p in PLATFORMS:
-		var px_left: int = int(p[0])
-		var px_right: int = int(p[1])
-		var py: int = int(p[2])
-		_solids.set_cell(Vector2i(px_left, py), 0, T_PLATFORM_L)
-		for mx in range(px_left + 1, px_right):
-			_solids.set_cell(Vector2i(mx, py), 0, T_PLATFORM_M)
-		_solids.set_cell(Vector2i(px_right, py), 0, T_PLATFORM_R)
+		_paint_floor_column(x, 22)
+	# Bridge platforms above each gap.
+	_paint_ground_strip(28, 30, 19)
+	_paint_ground_strip(36, 39, 18)
+	_paint_ground_strip(44, 46, 18)
+	# Stalactites.
+	_paint_stalactite(32, 12)
+	_paint_stalactite(40, 12)
 
 
-func _x_in_gap(x: int) -> bool:
-	for g in FLOOR_GAPS:
-		if x >= int(g[0]) and x < int(g[1]):
+func _paint_chunk_3_crystal_chamber() -> void:
+	# Floor at y=22 from x=50..52, then big chasm 53..62.
+	_paint_floor_row(50, 52, 22)
+	# Crystal platforms (crystal_surround + crystal_block mix).
+	_paint_crystal_strip(54, 55, 20)
+	_paint_crystal_strip(57, 58, 18)
+	_paint_crystal_strip(60, 61, 20)
+	# Floor 63..67.
+	_paint_floor_row(63, 67, 22)
+	# Mini chasm 68..71; crystal platform 69..70 at y=20.
+	_paint_crystal_strip(69, 70, 20)
+	# Floor 72..74.
+	_paint_floor_row(72, 74, 22)
+	# Vertical crystal pillars at x=63 and x=72, y=19..21.
+	for py in range(19, 22):
+		_solids.set_cell(Vector2i(63, py), 0, CRYSTAL_BLOCK)
+		_solids.set_cell(Vector2i(72, py), 0, CRYSTAL_BLOCK)
+
+
+func _paint_chunk_4_vertical_climb() -> void:
+	# Floor 75..79 at y=22.
+	_paint_floor_row(75, 79, 22)
+	# Left wall column at x=75, y=15..21.
+	for wy in range(15, 22):
+		_solids.set_cell(Vector2i(75, wy), 0, _pick(LEFT_EDGE_VARIANTS))
+	# Right wall column at x=99, y=8..21.
+	for wy in range(8, 22):
+		_solids.set_cell(Vector2i(99, wy), 0, _pick(RIGHT_EDGE_VARIANTS))
+	# Climbing staircase.
+	_paint_ground_strip(82, 84, 20)
+	_paint_ground_strip(87, 88, 18)
+	_paint_ground_strip(85, 86, 15)
+	_paint_ground_strip(89, 91, 12)
+	_paint_ground_strip(93, 95, 9)
+	# Stalactites.
+	_paint_stalactite(78, 5)
+	_paint_stalactite(88, 4)
+	_paint_stalactite(96, 4)
+
+
+func _paint_chunk_5_final_core() -> void:
+	# Floor at y=9 from x=100..119 with gap 107..111.
+	for x in range(100, 120):
+		if x >= 107 and x <= 111:
+			continue
+		_paint_floor_column(x, 9)
+	# Mid-pit precision platform at (x=109, y=7).
+	_paint_ground_strip(109, 109, 7)
+	# Crystal pillar at (x=115, y=4..8).
+	for py in range(4, 9):
+		_solids.set_cell(Vector2i(115, py), 0, CRYSTAL_BLOCK)
+	# Stalactites.
+	_paint_stalactite(102, 2)
+	_paint_stalactite(108, 1)
+	_paint_stalactite(113, 2)
+
+
+# ─── painter helpers ─────────────────────────────────────────────────────
+
+# Paint a horizontal run of ground (top row + sub-floor fill to map bottom).
+func _paint_floor_row(x_from: int, x_to_inclusive: int, top_y: int) -> void:
+	for x in range(x_from, x_to_inclusive + 1):
+		_paint_floor_column(x, top_y)
+
+
+# Paint a single column of floor: top tile at top_y, fill down to MAP_BOTTOM_Y.
+func _paint_floor_column(x: int, top_y: int) -> void:
+	_solids.set_cell(Vector2i(x, top_y), 0, _pick(GROUND_TOP_VARIANTS))
+	for fy in range(top_y + 1, MAP_BOTTOM_Y + 1):
+		_solids.set_cell(Vector2i(x, fy), 0, _pick(GROUND_FILL_VARIANTS))
+
+
+# Paint a one-tile-tall ground platform (no sub-fill).
+func _paint_ground_strip(x_from: int, x_to_inclusive: int, y: int) -> void:
+	for x in range(x_from, x_to_inclusive + 1):
+		_solids.set_cell(Vector2i(x, y), 0, _pick(GROUND_TOP_VARIANTS))
+
+
+# Paint a one-tile-tall crystal strip alternating surround / block for variety.
+func _paint_crystal_strip(x_from: int, x_to_inclusive: int, y: int) -> void:
+	for x in range(x_from, x_to_inclusive + 1):
+		var coord: Vector2i = CRYSTAL_SURROUND if ((x - x_from) % 2 == 0) else CRYSTAL_BLOCK
+		_solids.set_cell(Vector2i(x, y), 0, coord)
+
+
+# Place a stalactite on the non-colliding Stalactites layer.
+func _paint_stalactite(x: int, y: int) -> void:
+	_stalactites.set_cell(Vector2i(x, y), 0, _pick(STALACTITE_VARIANTS))
+
+
+func _x_in_any_range(x: int, ranges: Array) -> bool:
+	for r in ranges:
+		if x >= int(r[0]) and x <= int(r[1]):
 			return true
 	return false
 
 
+func _pick(variants: Array[Vector2i]) -> Vector2i:
+	return variants[_rng.randi() % variants.size()]
+
+
+# ─── actor placement ─────────────────────────────────────────────────────
 func _position_curiosity() -> void:
-	var floor_top_world: float = float(FLOOR_Y) * float(VISUAL_TILE)
-	# Curiosity collision rect = 88x432 at scene scale 0.5 → half-height 108.
+	# Floor in chunk 1 sits at tile y=22 → top edge at world y=1408.
+	# Curiosity body half-height = 108 (rect 88x432 at scene scale 0.5).
+	# Place her so the body bottom rests exactly on the floor top.
+	var floor_top_world: float = 22.0 * float(VISUAL_TILE)
 	_curiosity.position = Vector2(
 		float(SPAWN_TILE.x) * float(VISUAL_TILE) + float(VISUAL_TILE) * 0.5,
 		floor_top_world - 108.0
@@ -200,13 +294,13 @@ func _position_exit_door() -> void:
 	var door: Node2D = get_node_or_null("ExitDoor") as Node2D
 	if door == null:
 		return
-	# Door root sits ~340 above the floor — matches Hub's relative geometry,
-	# so the arch reads as towering and the interaction collider (rel y +125)
-	# lands just above Curiosity's body center.
-	var floor_top: float = float(FLOOR_Y) * float(VISUAL_TILE)
+	# Anchor at the exit tile center (per spec: pixel coord (7520, 544)).
+	# DoorArea collision (120x430, centered, no offset in scene) will then
+	# span y=329..759, fully overlapping Curiosity when she stands on the
+	# chunk-5 floor at y=9 (body center 468).
 	door.position = Vector2(
 		float(EXIT_DOOR_TILE.x) * float(VISUAL_TILE) + float(VISUAL_TILE) * 0.5,
-		floor_top - 340.0
+		float(EXIT_DOOR_TILE.y) * float(VISUAL_TILE) + float(VISUAL_TILE) * 0.5
 	)
 
 
@@ -215,7 +309,7 @@ func _setup_camera_limits() -> void:
 	if cam == null:
 		return
 	cam.limit_left = 0
-	cam.limit_right = LEVEL_WIDTH_TILES * VISUAL_TILE
+	cam.limit_right = LEVEL_WIDTH_TILES * VISUAL_TILE   # 7680
 	cam.limit_top = 0
-	cam.limit_bottom = 720
+	cam.limit_bottom = LEVEL_HEIGHT_TILES * VISUAL_TILE # 1920
 	cam.position_smoothing_enabled = true


### PR DESCRIPTION
Mechanical rebuild of Realm 1 to the new design spec. Five named chunks across a 120-wide x 30-tall tilemap at 2x scale → 7680x1920 world.

Closes #63

## Tile counts placed per chunk

**Chunk 1 — Intro Cave (x=0..24)**
- 25 floor columns @ y=22..29 = 25 ground_top + 175 fill = 200 solid cells
- Floating platforms: 4 cells (10..13, y=18) + 3 cells (18..20, y=17) = 7 ground_top
- 4 stalactites at (5,12) (8,12) (15,12) (22,12)

**Chunk 2 — Broken Cavern (x=25..49)**
- 13 floor columns (25..27, 32..36, 42..44, 48..49) @ y=22..29 = 13 ground_top + 91 fill = 104 solid cells
- Bridge platforms: 3 cells (28..30, y=19) + 4 cells (36..39, y=18) + 3 cells (44..46, y=18) = 10 ground_top
- 2 stalactites at (32,12) (40,12)

**Chunk 3 — Red Crystal Chamber (x=50..74)**
- Floor: x=50..52, 63..67, 72..74 → 11 ground_top + 77 fill = 88 solid cells
- Crystal platforms (surround/block mix): 2+2+2+2 = 8 cells
- Crystal pillars: 2 columns × 3 cells = 6 crystal_block cells

**Chunk 4 — Vertical Climb (x=75..99)**
- Floor: x=75..79 → 5 ground_top + 35 fill = 40 solid cells
- Left wall (x=75, y=15..21): 7 left_edge cells
- Right wall (x=99, y=8..21): 14 right_edge cells
- Staircase: 3+2+2+3+3 = 13 ground_top cells
- 3 stalactites at (78,5) (88,4) (96,4)

**Chunk 5 — Final Core Chamber (x=100..119)**
- Floor: x=100..106, 112..119 → 15 ground_top + 300 fill = 315 solid cells
- Precision platform (109, y=7): 1 ground_top
- Crystal pillar (x=115, y=4..8): 5 crystal_block
- 3 stalactites at (102,2) (108,1) (113,2)

## Coords confirmed
- **Spawn pixels:** (160, 1300) — tile (2,20) center on X, body bottom flush with floor top y=1408 on Y
- **Exit door pixels:** (7520, 544) — tile (117,8) center per spec
- **Camera limits:** 0..7680 horizontal, 0..1920 vertical

## Parallax coverage
All 8 layers switched from `motion_scale.y = 1` to `motion_scale.y = 0`. The 720-tall sprites are now viewport-locked vertically, so they fill the screen at any camera Y position across the new 1920-tall world — no grey gap at top or bottom.

## Spec ambiguities resolved
1. **Spawn pixels.** Spec says (160, 1312); literal value would embed Curiosity's body (half-height 108) in the floor at world y=1408. Used (160, 1300) so body bottom = floor top, satisfying the spec's own "no falling through" check.
2. **Exit door collision.** Door root anchored at tile (117,8) center per spec. The 120x430 collision rect (centered, no Y offset) spans y=329..759 — covers Curiosity body when she's standing on the chunk-5 floor (body center 468).
3. **Ground fill depth.** Spec describes fill as "mass interior" but only enumerates the top row of each floor. Filled every floor column down to y=29 (map bottom) so chunk-5's high floor reads as solid earth and the chasms genuinely interrupt the mass.
4. **Wall column composition.** "Left wall (x=75, y=15..21) using left_edge + fills" — interpreted as a single column of LEFT_EDGE variants (no embedded fill cells, which would be redundant inside a one-tile-thick wall).
5. **Reachability vs. physics.** Spec's verification rule says "every jump must be ≤3 tiles vertical," but current Curiosity tuning (gravity 350, jump_velocity -240) gives a peak of ~1.3 visual tiles. Most spec'd platforms (e.g. floor y=22 → platform y=18) are unreachable without a physics retune. Placed exactly as spec'd; flagging here since the user explicitly forbade creative deviation.

## Test plan
- [ ] Wait for deploy.yml to import + export cleanly on main after merge
- [ ] Live URL: hub → realm 1 door
- [ ] Confirm parallax fills viewport at top, middle, and bottom camera positions
- [ ] Confirm spawn lands on floor, exit door interaction triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)