### PR TITLE
docs: tighten the agentic loop so sessions boot cheap

### DIFF
--- a/.github/ISSUE_TEMPLATE/art.md
+++ b/.github/ISSUE_TEMPLATE/art.md
@@ -26,9 +26,14 @@ labels: ["art"]
 ## Integration target
 <!-- Which scene/node will receive this asset? Path to the .tscn or node, e.g. scenes/Hub.tscn → ParallaxBackground/Far. -->
 
-## Acceptance
+## Acceptance criteria
 - [ ] Matches docs/ART_DIRECTION.md (palette, line treatment, texture, scale)
 - [ ] Imports cleanly via `godot --headless --import`
 - [ ] Wired into the target scene
 - [ ] Web export still passes
 - [ ] Looks like a painting in the running game, not a placeholder
+
+## Kill criteria
+<!-- Revert if X by Y. One bullet. Forces the "what would make me
+     pull this back" question UP FRONT, not after merge. -->
+- [ ] Revert if:

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -25,5 +25,10 @@ labels: ["feat"]
 - [ ] Adheres to docs/ART_DIRECTION.md and docs/VIBE.md
 - [ ] CLAUDE.md / docs/ updated if conventions changed
 
+## Kill criteria
+<!-- Revert if X by Y. One bullet. Forces the "what would make me
+     pull this back" question UP FRONT, not after merge. -->
+- [ ] Revert if:
+
 ## Visual / audio references (optional)
 <!-- Mood-board fragments, color refs, sound refs, or a short prose description. -->

--- a/.github/ISSUE_TEMPLATE/realm.md
+++ b/.github/ISSUE_TEMPLATE/realm.md
@@ -1,0 +1,51 @@
+---
+name: Realm
+about: Queue a new realm for design + build
+title: "realm: "
+labels: ["realm"]
+---
+
+## Theme word
+<!-- One word or two-word phrase. The emotional/symbolic spine of the realm.
+     e.g. "forgotten names", "quiet hunger", "folded hour". -->
+
+## Palette refs (3 colors min)
+<!-- Pin hex codes from docs/ART_DIRECTION.md OR new palette drifts.
+     Name what dominates and what stays the lantern's accent.
+     e.g.
+     - Dominant: #2d1b4e (purple-violet)
+     - Mid:      #1c2a3a (slate grey-blue)
+     - Accent:   #f5b870 (lantern gold — unchanged) -->
+
+## Puzzle premise (one sentence)
+<!-- What does the player DO to pass through? Verb-shaped, not noun-shaped.
+     e.g. "Curiosity collects jade fragments scattered through a cave." -->
+
+## Lore beat on exit (one line)
+<!-- The single line of voice-text Curiosity speaks as the realm fades.
+     Match the tone in docs/VOICE.md. Advika writes this — don't invent. -->
+
+## What player carries forward into the hub
+<!-- Item, memory, key-fragment, visible change to the cloak, etc.
+     This is what makes the realm matter back at the hub. -->
+
+## Files likely touched
+<!-- Best guess at scenes/scripts/assets in scope. -->
+
+## Acceptance criteria
+- [ ] `godot --headless --import` passes
+- [ ] `godot --headless --export-release "Web" build/index.html` passes
+- [ ] Visually verified in browser on the live site (or local equivalent)
+- [ ] No regression in feel or performance
+- [ ] Adheres to docs/ART_DIRECTION.md and docs/VIBE.md
+- [ ] Realm entry registered in `Door.gd::_resolve_scene_path`
+- [ ] docs/STATE.md "Live loop" and "What is wired" updated
+- [ ] docs/REALMS.md entry promoted from drafted → in-build or shipped
+
+## Kill criteria
+<!-- Revert if X by Y. One bullet. Forces the "what would make me
+     pull this back" question UP FRONT, not after merge. -->
+- [ ] Revert if:
+
+## Visual / audio references (optional)
+<!-- Mood-board fragments, color refs, sound refs, or a short prose description. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,13 @@ Every PR must:
 - (d) reference an issue (`Closes #N`) — no orphan PRs except the meta-workflow PR itself
 
 ## Session Start Protocol
-At the start of every session, before touching code, do these in order:
-1. Read `CLAUDE.md` (this file)
-2. Read every file in `docs/` — VISION, ART_DIRECTION, REALMS, MECHANICS, STORY, VIBE
-3. Run `gh issue list --state open` to see what's queued
-4. Run `gh pr list` to see what's already in flight
-Only then propose or accept work.
+Before touching code:
+1. Read `CLAUDE.md` (this file) + `docs/STATE.md`
+2. Read the open issue you're picking up (`gh issue view N`)
+3. Read ONLY the one design doc the issue touches (VISION / ART_DIRECTION / MECHANICS / REALMS / STORY / VIBE)
+4. Run `gh issue list --state open` + `gh pr list`
+
+Skim, don't read, anything else. `docs/STATE.md` is the truth.
 
 ## Tech
 - **Engine:** Godot 4.6 (GDScript, Forward+ renderer)
@@ -87,7 +88,12 @@ Scope tags (`feat(hero):`, `fix(ci):`) are welcome when they clarify.
 
 For the full painterly bible, see `docs/ART_DIRECTION.md`. For tone-words allow/deny lists, see `docs/VIBE.md`.
 
-## Current Skeleton Status
-- Placeholder `ColorRect` stands in for Curiosity's painted sprite
-- `GradientTexture2D` radial placeholder for the lantern light — replace with a hand-drawn falloff when art lands
-- No parallax, no fog, no doors, no realms yet — these are the next feature branches
+## Chat protocol — how the brain evolves
+
+The design lives in `INTENT.md`, `docs/realms/*`, and `docs/SKETCHBOOK.md`. It grows by chat, not by checklist.
+
+- **At session start**, ask: *"Anything you've been thinking about the game since we last spoke?"* Capture the answer before code — `docs/SKETCHBOOK.md` if rough, a realm spec if specific.
+- **Mid-session**, if Advika says something idea-shaped (a new realm, a new puzzle, a new character), pause, write it to `docs/SKETCHBOOK.md` with today's date, continue.
+- **At session end**, ask: *"Anything new today we should write down before we close?"* Capture it.
+
+No interrogation. One open question at the right moments. The brain grows by listening, not by quizzing.

--- a/docs/MECHANICS.md
+++ b/docs/MECHANICS.md
@@ -1,105 +1,218 @@
 # Mechanics
 
-Every system that runs the game, present or planned. Update this when systems land or change shape.
+Engineering reference for every system that runs the game. **For the living
+snapshot of what's wired *right now*, see `docs/STATE.md` — that's the truth
+between sessions. This doc is the longer system spec.**
+
+Update this when systems land, change shape, or move between sections.
 
 ---
 
-## Existing Systems
+## Current Implemented Loop
+
+End-to-end thing the player can do today:
+
+1. Start in **Hub.tscn** — Curiosity stands in a painted chamber with a single
+   door (Door 1) painted into the scene. Parallax + ambient particles wash the
+   background.
+2. Walk Curiosity right with `move_left` / `move_right` (arrow keys or A/D),
+   run with `Shift`, jump with `jump` (space).
+3. Approach Door 1 → a floating `[Y] Enter` prompt fades in.
+4. Press `interact` (Y) → the door flashes warm, holds the flash, then
+   `Transition` autoload fades-out and loads **Realm1.tscn**.
+5. **Realm1 — "The Crimson Hollow"** — a hand-built cave platformer with
+   four floor gaps, ten platforms, and an exit door on the right wall.
+6. Reach the exit door → same interact pattern → fade back to **Hub.tscn**,
+   and Curiosity respawns one step beside the door she came back through.
+
+That is the playable loop. Web build of this loop ships to GitHub Pages on
+every push to `main`.
+
+---
+
+## Implemented
+
+Systems that exist in code and are wired into the loop above.
 
 ### Curiosity (CharacterBody2D)
 - File: `scripts/Curiosity.gd`, `scenes/Curiosity.tscn`
-- Side-scrolling movement: left/right with `move_left` / `move_right` input actions
-- Gravity from project settings
-- Single jump on `jump` input action
-- Currently a `ColorRect` placeholder — sprite art TBD
+- Side-scrolling movement: walk / run (Shift sprint) / single jump, gravity
+  tuned low (~350) for a drifting feel rather than arcade-snap.
+- State machine: `IDLE / WALK / RUN / JUMP_START / AIR / LAND`. Animation
+  per state via `AnimatedSprite2D`.
+- Lantern follow + sway: lantern + flame tween across the body when facing
+  flips (`lantern_sway_time = 0.2s`, sine ease-out).
+- Source art faces LEFT — `flip_h = true` is right-facing.
 
-### Lantern (PointLight2D)
-- Child of Curiosity
-- `GradientTexture2D` radial placeholder — replace with hand-painted falloff when art lands
-- Warm accent color (`#f5b870`); energy currently static
-- Planned: organic flicker via noise-driven energy modulation
+### Lantern
+- Child of Curiosity (`$Lantern`, `PointLight2D`).
+- Texture is still a `GradientTexture2D` radial placeholder. Replace with a
+  hand-painted falloff when art lands.
+- `$LanternFlame` (`Sprite2D`) overlays the warm flame and gets a soft
+  sine-based alpha flicker (amplitude 0.05, period 0.4s) in `_process`.
+
+### Door + Hub interaction
+- Files: `scripts/Door.gd`, `scripts/Hub.gd`.
+- Reusable `Door` is an `Area2D` with `near_door` / `left_door` signals.
+  Each door joins the `doors` group on ready.
+- `Hub.gd` owns the single `interact` poll — tracks which door is current
+  and calls `trigger()` on press. Prevents N doors all polling input.
+- `trigger()` flashes the door glow + swaps prompt text, holds 0.3s for
+  visible feedback, then routes through `Transition`.
+- Realm-bound trips persist `door_id` via `Transition.last_door_id` so Hub
+  can respawn Curiosity at the same door on return.
+
+### Scene Transition (autoload)
+- File: `scripts/SceneTransition.gd`, registered as `Transition` autoload.
+- Single API: `Transition.transition_to(path)` — fades a Control overlay
+  black → loads scene → fades back.
+- Exposes `last_door_id` for hub respawn.
+
+### Parallax (Hub + Realm 1)
+- Hub uses painted parallax layers (nebula, stone floor backdrops, drifting
+  motes).
+- Realm 1 uses an 8-layer parallax cave painting set
+  (`assets/realms/realm1_caves/parallax/0..7.png`).
+
+### Realm 1 — "The Crimson Hollow"
+- File: `scripts/Realm1.gd`, `scenes/realms/Realm1.tscn`.
+- TileSet built at runtime from `mainlev_build.png` with a single ground-top
+  tile, single ground-fill (4 rows deep), and a 3-tile wood-plank platform
+  palette.
+- Layout: 80 floor cells, 4 evenly-spaced 4-tile gaps, 10 platforms
+  including a y=6/7/8 ascending victory path before the exit door.
+- Collision attached per-tile (the bug fix in PR #54: `add_source` must come
+  *before* the per-tile `create_tile + attach_full_collision` loop or the
+  physics layer doesn't propagate and every tile silently has zero collision).
+
+### Touch Controls
+- File: `scripts/TouchControls.gd`, `scenes/TouchControls.tscn`.
+- Virtual joystick-style controls for touch browsers. Hidden by default on
+  desktop, surfaced on touch-capable web.
 
 ### Web Export Pipeline
-- Godot 4.6 Forward+ → HTML5 export preset "Web"
-- GitHub Actions workflow `.github/workflows/*.yml` builds and publishes to GitHub Pages on every push to `main`
-- `.nojekyll` written to allow underscored asset paths
+- Godot 4.6 Forward+ → HTML5 export preset "Web".
+- GitHub Actions workflow in `.github/workflows/*.yml` builds and publishes
+  to GitHub Pages on every push to `main`.
+- `.nojekyll` written so underscored asset paths serve.
 
 ---
 
-## Planned Systems
+## Known Stubs / Out of Scope
 
-These are the rails the game is being built on. Each becomes its own issue (or chain of issues) when scheduled.
+Things that exist as assets, comments, or partial code but are NOT currently
+wired into the playable loop. Listed here so future sessions don't think
+they're real.
 
-### Parallax Background Layers
-- Three layers minimum: far, mid, near
-- ParallaxBackground + ParallaxLayer nodes
-- Each layer: a hand-painted texture, scrolling at its own rate, with seam-tolerant tiling
-- Per-realm: distinct asset set, distinct color palette, distinct fog density
+### Unwired Curiosity animations
+SpriteFrames includes `attack1`, `attack2`, `charged`, `dash`, `hurt`,
+`approach`, `lever_pull`, `lever_hold`, `celebrate`. None of these are
+reachable from the state machine. See the `# TODO` at the top of
+`scripts/Curiosity.gd` — wiring lands when enemies and lever puzzles exist.
+
+### Stub doors
+Hub may paint Door 2 / Door 3 into the scene visually, but `_resolve_scene_path`
+in `Door.gd` only knows `realm_1` and `hub`. Any other `target_realm` value
+prints `[Door] Realm not yet built: ...` and stays open for retry. They are
+intentional stubs.
+
+### Docs-only systems
+The following are described in this file's **Planned** section and elsewhere
+but **have no Godot implementation yet**:
+- Save / load
+- Dialogue / lore textbox overlay (will be needed for Curiosity-spoken text)
+- Puzzle framework (abstract `Puzzle` base class)
+- Hub layout system (currently hand-authored doors only)
+- Settings / pause overlay
+- Per-realm ambient audio bus structure
+- Hand-painted lantern falloff (still gradient placeholder)
+- Cloak shader / eye-blink shader / fog shader
+
+### Lore moment on Realm 1 exit
+Queued spec — a short single-line Curiosity textbox before the exit fade.
+Needs the dialogue overlay before it can ship.
+
+---
+
+## Planned
+
+Rails the game is being built on. Each becomes its own issue when scheduled.
 
 ### Particle Systems
-- **Drifting motes:** GPUParticles2D, soft circular sprites, slow vertical drift with subtle horizontal sway
-- **Atmospheric fog:** scrolling shader-driven band or large transparent particle quads
-- **Embers:** warm particles near the lantern and braziers, occasional, gravity-affected
-- **Per-realm overrides:** quantity, color, drift speed shaped by realm theme
-
-### Dynamic Lighting
-- `CanvasModulate` set near-black for the base world
-- Lantern PointLight2D as the primary key light with organic flicker (noise-modulated energy in a tight band)
-- Secondary lights as environmental rarities — a distant window, a brazier, glowing flora
-- Shadow casters on foreground silhouettes; painterly hand-authored falloff textures preferred over technical raycasting
+- **Drifting motes:** GPUParticles2D, soft circular sprites, slow vertical
+  drift with subtle horizontal sway. (Already wired in Hub; per-realm
+  overrides not yet implemented.)
+- **Atmospheric fog:** scrolling shader-driven band or large transparent
+  particle quads.
+- **Embers:** warm particles near the lantern and braziers.
 
 ### Shaders
-- **Cloak shader:** vertex distortion or layered animated mask to simulate fabric sway, lagging behind body motion
-- **Eye-blink pattern shader:** UV-driven mask that opens / holds / closes the cloak's eyes on a slow irregular cadence
-- **Fog shader:** noise-driven offset on a tinted band, drifting horizontally
-- **Painterly post-process (optional, late):** subtle grain + warm/cool split-tone
+- **Cloak shader:** vertex distortion or layered animated mask to simulate
+  fabric sway, lagging behind body motion.
+- **Eye-blink pattern shader:** UV-driven mask that opens / holds / closes
+  the cloak's eyes on a slow irregular cadence.
+- **Fog shader:** noise-driven offset on a tinted band, drifting horizontally.
+- **Painterly post-process (optional, late):** subtle grain + warm/cool split-tone.
 
 ### Ambient Audio
-- Per-realm ambient bed (looping, low headroom)
-- Diegetic accent layer (distant bells, wind, footsteps on different surfaces)
-- Lantern flicker has a soft sonic correlate
-- AudioStreamPlayer2D for positional cues; AudioStreamPlayer for global beds
-- Bus structure: Master → Music → Ambient → SFX, with fade-in/out helpers per realm
-
-### Scene Transition System
-- A central `Transitions` autoload, single API: `Transitions.go_to(scene_path)`
-- Fade-out on a Control overlay (slow black-to-clear, ~1.5s)
-- Optional lantern dim on entry, lantern wake on arrival
-- Preserves player position relative to door geometry on hub return
-
-### Door Interaction System
-- `Door` scene with collision area + interactable prompt zone
-- On `interact` input within range: trigger transition to target realm scene
-- Doors stay open after first traversal (a returned-from realm reads differently)
-- Door state persisted through the save system
-
-### Puzzle Framework
-- Abstract `Puzzle` base class: `is_solved()`, `on_solve()`, `on_reset()`
-- Each realm subclasses with its own state model
-- Puzzle solve event hooks the lore reveal + door-back-to-hub unlock
+- Per-realm ambient bed (looping, low headroom).
+- Diegetic accent layer (distant bells, wind, footsteps on different surfaces).
+- Lantern flicker has a soft sonic correlate.
+- Bus structure: Master → Music → Ambient → SFX with fade helpers per realm.
 
 ### Dialogue / Lore Overlay
-- A reverent text presenter — slow fade-in, generous holds, slow fade-out
-- Soft serif or hand-lettered font (no system sans-serif)
-- Single line at a time; no boxes, no portraits, no ticking crawl
-- Triggerable by zone, puzzle event, or lantern proximity to a lore object
+- Reverent text presenter — slow fade-in, generous holds, slow fade-out.
+- Soft serif or hand-lettered font (no system sans-serif).
+- Single line at a time; no boxes, no portraits, no ticking crawl.
+- Triggerable by zone, puzzle event, or lantern proximity to a lore object.
+- **Curiosity speaks through this system** — see `docs/VOICE.md` for tone.
+
+### Puzzle Framework
+- Abstract `Puzzle` base class: `is_solved()`, `on_solve()`, `on_reset()`.
+- Each realm subclasses with its own state model.
+- Puzzle solve event hooks the lore reveal + door-back-to-hub unlock.
 
 ### Save System
-- JSON-serialized save file under user:// — minimal: doors opened, realms completed, lantern state, lore fragments collected
-- Auto-save on door transition; no save UI initially
-- Robust to schema additions (versioned save format)
-
-### Mobile Touch Controls
-- Virtual joystick or tap-zones for left/right
-- Tap-anywhere-on-right-half for jump
-- Toggleable; auto-detect on touch-capable browsers
-- Hidden by default on desktop
+- JSON under `user://` — doors opened, realms completed, lantern state,
+  lore fragments collected, collectibles (jade pieces, etc.).
+- Auto-save on door transition; no save UI initially.
+- Versioned save format for robustness to schema additions.
 
 ### Hub Layout System
-- The hub itself is a scene with door slots
-- New doors appear (fade-in) as realms become available
-- Door positioning is hand-authored, not procedural
+- Hub as a scene with door slots; new doors fade in as realms become
+  available. Door positioning hand-authored, not procedural.
+- Forward goal: topsy-turvy, multi-angle door arrangement per the
+  2026-05-17 hub concept (see `docs/HUB.md`).
+
+### Realm 1 collectibles
+- **Jade crystal pieces.** Curiosity gathers them through the realm; on
+  return to Hub, they're forged into the jade key that unlocks Door 2.
+  This loop is Realm-1-specific; later realms have their own concepts.
 
 ### Settings / Pause
-- Minimal pause overlay — fade the world, expose only "resume" and "return to hub"
-- Settings later: volume sliders, controls remap (mobile / desktop)
+- Minimal pause overlay — fade the world, expose only "resume" and "return
+  to hub". Volume / controls remap later.
+
+---
+
+## Next Safe Feature Candidates
+
+Small, scoped, low-risk next steps. Pick from here when starting a session;
+none of these require designing a new system from scratch.
+
+1. **Realm 1 lore moment (queued spec)** — one short Curiosity-voice line
+   on Realm 1 exit before the fade. Local to the realm, no global dialogue
+   framework needed yet.
+2. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
+   tracked in a global singleton, hub-side "forge the key" moment on
+   return. Foundation for the Realm 1 → Door 2 unlock loop.
+3. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
+   the solid sub-floor block. A peak-top platform tile (e.g. row-22 rocky-
+   band coords) would read more as a floating ledge than a chunk of
+   detached floor.
+4. **Audit the parallax cave painting against the brown-cave foreground** —
+   the deepest layer is still a cool blue-grey while the tiles are warm
+   brown. The tonal split shows when there's an exposed gap.
+5. **Hand-painted lantern falloff** — replace the `GradientTexture2D`
+   placeholder with a painterly radial falloff. Pure art swap, no
+   gameplay change.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -7,6 +7,51 @@ Format: `date | what shipped | what didn't work | next 3 safe candidates`
 
 ---
 
+## 2026-05-17 — Tighten the agentic loop
+
+**Shipped**
+- `docs/STATE.md` introduced as the single living snapshot of what's wired
+  vs. unwired right now. Updated at the end of every session. Becomes the
+  primary boot-up read alongside `CLAUDE.md`.
+- `CLAUDE.md` reality-synced: deleted the stale "Current Skeleton Status"
+  block (was still claiming `ColorRect` placeholder + no parallax + no doors),
+  replaced the "Session Start Protocol" with a leaner four-step version
+  that reads `STATE.md` + the issue + ONE relevant design doc, instead of
+  the full `docs/` tree.
+- `docs/MECHANICS.md` reality-synced against current code: split into
+  **Current Implemented Loop / Implemented / Known Stubs / Planned / Next
+  Safe Feature Candidates**. Removed `ColorRect` / `GradientTexture2D` lies,
+  documented the Door + Hub + Transition wiring as shipped, listed the
+  un-wired Curiosity animations as explicit stubs. Closes #57.
+- `.github/ISSUE_TEMPLATE/feat.md` + `art.md` now have a **Kill criteria**
+  section right after Acceptance — forces the "what would make me pull
+  this back?" question up front instead of post-merge.
+- `.github/ISSUE_TEMPLATE/realm.md` added — new template for queuing
+  realms. Fields: Theme word, Palette refs (3 colors min), Puzzle premise
+  (one sentence), Lore beat on exit (one line), What player carries
+  forward into the hub. Acceptance copied from `feat.md`, Kill criteria
+  required.
+- Bundled the `Chat protocol — how the brain evolves` section that was
+  added to `CLAUDE.md` during the 2026-05-17 design session — same theme
+  (cheap session boot), rolling it forward into `main`.
+
+**What didn't work / dead ends**
+- None this session — pure docs / meta work, no code paths exercised.
+
+**Next 3 safe candidates**
+1. Realm 1 lore moment (queued spec) — one short Curiosity-voice line on
+   Realm 1 exit before the fade. Local to the realm, no global dialogue
+   framework needed yet.
+2. Realm 1 jade-piece pickups — scattered collectible nodes, counter
+   tracked in a global singleton, hub-side "forge the key" moment on
+   return. Foundation for the Realm 1 → Door 2 unlock loop.
+3. Polish pass on platform rocks — `T_PLATFORM_L/M/R` currently reuse the
+   solid sub-floor block. A peak-top platform tile (e.g. row-22 rocky-band
+   coords) would read more as a floating ledge than a chunk of detached
+   floor.
+
+---
+
 ## 2026-05-11 — Realm 1 full geometry rebuild (classic platformer)
 
 **Shipped**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,0 +1,39 @@
+# Current State (auto-narrative — update at end of every session)
+_Last updated: 2026-05-17_
+
+## Live loop
+Hub.tscn ↔ Realm1 (cave traversal) ↔ Hub return. Door 1 wired.
+Door 2 / Door 3: stubs.
+
+## What is wired
+- Curiosity locomotion: idle / walk / run / jump / air / land
+- Lantern PointLight2D with placeholder gradient + soft flame flicker
+- Parallax in Hub + Realm 1
+- Tilemap floor + platforms in Realm 1 (brown-cave palette)
+- Door interact (Y key) → scene transition with fade
+- Hub respawn at the door Curiosity returned through
+- Touch controls scene (mobile / touch-browser)
+- GitHub Pages auto-deploy on merge to main
+
+## What exists but is unwired
+- Combat / dash / lever / approach / hurt / charged / celebrate animations
+  on Curiosity (frames imported, not reachable from state machine)
+- Save system, dialogue overlay, puzzle framework (all docs-only)
+- Hand-painted lantern falloff (still gradient placeholder)
+- Cloak / eye-blink / fog shaders
+- Per-realm ambient audio
+
+## Last session
+[2026-05-17 — Tighten the agentic loop](SESSIONS.md#2026-05-17--tighten-the-agentic-loop)
+
+## Next 3 safe candidates
+1. **Realm 1 lore moment (queued spec)** — one short Curiosity-voice line
+   on Realm 1 exit before the fade. Local to the realm, no global dialogue
+   framework needed yet.
+2. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
+   tracked in a global singleton, hub-side "forge the key" moment on
+   return. Foundation for the Realm 1 → Door 2 unlock loop.
+3. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
+   the solid sub-floor block. A peak-top platform tile (e.g. row-22
+   rocky-band coords) would read more as a floating ledge than a chunk
+   of detached floor.


### PR DESCRIPTION
## Summary
- Introduces `docs/STATE.md` as the single living snapshot of "what is the game right now," so future sessions read one short file instead of the whole `docs/` tree
- Reality-syncs `CLAUDE.md` (deletes the stale `Current Skeleton Status` block, swaps in a leaner four-step `Session Start Protocol`) and `docs/MECHANICS.md` (splits Implemented / Known Stubs / Planned, removes the `ColorRect` + `GradientTexture2D` lies, documents the shipped Door + Hub + Transition wiring)
- Adds a `Kill criteria` section to `feat.md` and `art.md` and a new `realm.md` issue template for queuing realms

Closes #57.

## What's in the diff
| File | Change |
| --- | --- |
| `docs/STATE.md` | **new** — auto-narrative snapshot, updated end-of-session |
| `CLAUDE.md` | deleted stale Skeleton block; leaner Session Start Protocol; chat-protocol section rolled forward from prior design session |
| `docs/MECHANICS.md` | restructured: Current Implemented Loop / Implemented / Known Stubs / Planned / Next Safe Feature Candidates |
| `.github/ISSUE_TEMPLATE/feat.md` | + Kill criteria after Acceptance |
| `.github/ISSUE_TEMPLATE/art.md` | + Kill criteria after Acceptance (also normalized `Acceptance` → `Acceptance criteria`) |
| `.github/ISSUE_TEMPLATE/realm.md` | **new** — Theme word, Palette refs, Puzzle premise, Lore beat on exit, What player carries forward |
| `docs/SESSIONS.md` | new entry: `2026-05-17 — Tighten the agentic loop` |

## Test plan
- [ ] `gh pr view` renders the issue templates correctly (web check)
- [ ] Open a new issue against the repo with the `Realm` template → fields populate
- [ ] `godot --headless --import` still passes (docs-only change, but per Quality Gate)
- [ ] `godot --headless --export-release "Web" build/index.html` still passes
- [ ] CI green on main after merge

## Kill criteria
- [ ] Revert if: STATE.md drifts out of sync within the first two sessions — that would mean the protocol isn't actually being followed and the file is worse than no file. Fix is to make the end-of-session STATE.md update a hard step in the chat protocol, not a soft one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)