### PR TITLE
feat: Realm 1 lore moment via reusable LoreMoment overlay

### DIFF
--- a/docs/MECHANICS.md
+++ b/docs/MECHANICS.md
@@ -90,6 +90,18 @@ Systems that exist in code and are wired into the loop above.
 - Virtual joystick-style controls for touch browsers. Hidden by default on
   desktop, surfaced on touch-capable web.
 
+### LoreMoment overlay (single-line, awaitable)
+- Files: `scripts/LoreMoment.gd`, `scenes/UI/LoreMoment.tscn`.
+- Reusable single-line lore display: CanvasLayer at layer=100, centered
+  Label, soft serif via `SystemFont` fallback chain, no box, no portrait,
+  no ticking crawl.
+- Lifecycle: fade-in (1.0s, sine ease-out) → hold (3.0s) → fade-out (1.0s,
+  sine ease-in) → `queue_free`. Awaitable: `await lore.play_line(text)`.
+- Wired via `Door.exit_lore_line` (`@export_multiline String`). If set,
+  `Door.trigger()` plays the line between its flash-feedback hold and the
+  `Transition.transition_to()` fade. Empty value = no behavior change.
+- Realm 1's exit door uses it to land one beat before returning to Hub.
+
 ### Web Export Pipeline
 - Godot 4.6 Forward+ → HTML5 export preset "Web".
 - GitHub Actions workflow in `.github/workflows/*.yml` builds and publishes
@@ -120,17 +132,14 @@ intentional stubs.
 The following are described in this file's **Planned** section and elsewhere
 but **have no Godot implementation yet**:
 - Save / load
-- Dialogue / lore textbox overlay (will be needed for Curiosity-spoken text)
+- Multi-line dialogue overlay with positional triggers (the single-line
+  lore case is shipped — see "LoreMoment overlay" in Implemented)
 - Puzzle framework (abstract `Puzzle` base class)
 - Hub layout system (currently hand-authored doors only)
 - Settings / pause overlay
 - Per-realm ambient audio bus structure
 - Hand-painted lantern falloff (still gradient placeholder)
 - Cloak shader / eye-blink shader / fog shader
-
-### Lore moment on Realm 1 exit
-Queued spec — a short single-line Curiosity textbox before the exit fade.
-Needs the dialogue overlay before it can ship.
 
 ---
 
@@ -160,11 +169,16 @@ Rails the game is being built on. Each becomes its own issue when scheduled.
 - Lantern flicker has a soft sonic correlate.
 - Bus structure: Master → Music → Ambient → SFX with fade helpers per realm.
 
-### Dialogue / Lore Overlay
-- Reverent text presenter — slow fade-in, generous holds, slow fade-out.
-- Soft serif or hand-lettered font (no system sans-serif).
-- Single line at a time; no boxes, no portraits, no ticking crawl.
-- Triggerable by zone, puzzle event, or lantern proximity to a lore object.
+### Dialogue / Lore Overlay (extensions beyond LoreMoment)
+- LoreMoment ships the single-line variant for door-exit beats. The
+  larger system still planned:
+  - Multi-line passages with paced reveal between lines.
+  - In-realm triggers (proximity zones, puzzle-solve events, lantern-on-
+    lore-object detection) rather than only door-bound playback.
+  - Optional Curiosity-voice register vs. environmental-narration
+    register — same overlay, different cadence/font weight.
+  - Bundled painterly serif `.ttf` to replace the `SystemFont` fallback
+    chain.
 - **Curiosity speaks through this system** — see `docs/VOICE.md` for tone.
 
 ### Puzzle Framework
@@ -200,19 +214,18 @@ Rails the game is being built on. Each becomes its own issue when scheduled.
 Small, scoped, low-risk next steps. Pick from here when starting a session;
 none of these require designing a new system from scratch.
 
-1. **Realm 1 lore moment (queued spec)** — one short Curiosity-voice line
-   on Realm 1 exit before the fade. Local to the realm, no global dialogue
-   framework needed yet.
-2. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
+1. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
    tracked in a global singleton, hub-side "forge the key" moment on
    return. Foundation for the Realm 1 → Door 2 unlock loop.
-3. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
+2. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
    the solid sub-floor block. A peak-top platform tile (e.g. row-22 rocky-
    band coords) would read more as a floating ledge than a chunk of
    detached floor.
-4. **Audit the parallax cave painting against the brown-cave foreground** —
+3. **Audit the parallax cave painting against the brown-cave foreground** —
    the deepest layer is still a cool blue-grey while the tiles are warm
    brown. The tonal split shows when there's an exposed gap.
-5. **Hand-painted lantern falloff** — replace the `GradientTexture2D`
+4. **Hand-painted lantern falloff** — replace the `GradientTexture2D`
    placeholder with a painterly radial falloff. Pure art swap, no
    gameplay change.
+5. **Painterly serif `.ttf` for LoreMoment** — bundle a free-license
+   serif so the lore overlay stops depending on host-system fonts.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -7,6 +7,53 @@ Format: `date | what shipped | what didn't work | next 3 safe candidates`
 
 ---
 
+## 2026-05-17 — Realm 1 lore moment + LoreMoment scene
+
+**Shipped**
+- New reusable `LoreMoment` overlay (`scenes/UI/LoreMoment.tscn` +
+  `scripts/LoreMoment.gd`) — single-line lore display: slow fade-in /
+  hold / fade-out, soft serif via `SystemFont` fallback chain (Georgia →
+  Times New Roman → DejaVu Serif → Liberation Serif → serif), centered,
+  no box, no portrait, no ticking crawl. Self-frees after the fade-out.
+  Awaitable from any caller: `await lore.play_line(text)`.
+- `Door.gd` extended with an `exit_lore_line` `@export_multiline` field.
+  When non-empty, `trigger()` spawns a LoreMoment under the current
+  scene, awaits its full ~5s cycle, then continues into the existing
+  `Transition.transition_to(path)` fade. Empty value = no behavior
+  change, so existing doors stay exactly as they were.
+- Realm 1's `ExitDoor/DoorArea` now sets:
+  `exit_lore_line = "The dark grew careful where her lantern had been."`
+  — lantern-anchored imagery from the book, "grew careful" implies the
+  cave reacted without narrating that it did. Past tense gives
+  after-presence.
+- `docs/STATE.md` updated: LoreMoment moved to "What is wired,"
+  dialogue-overlay removed from "unwired," Live loop reflects the lore
+  step before the fade.
+- Closes #66.
+
+**What didn't work / dead ends**
+- No bundled `.ttf` serif font available — relied on `SystemFont` with a
+  Georgia → Times → DejaVu Serif → Liberation Serif → serif fallback
+  chain. On the live web build this should resolve to a real serif on
+  Windows / macOS / Android browsers; Linux without DejaVu falls back to
+  Godot's default sans. Bundling a free-license painterly serif is the
+  obvious polish follow-up but didn't make this PR.
+- Couldn't run `godot --headless --import` locally (Godot not on PATH on
+  the working machine). Relied on careful code review + post-merge CI as
+  the Quality Gate.
+
+**Next 3 safe candidates**
+1. Realm 1 jade-piece pickups — scattered collectible nodes, counter
+   tracked in a global singleton, hub-side "forge the key" moment on
+   return. Foundation for the Realm 1 → Door 2 unlock loop.
+2. Polish pass on platform rocks — peak-top platform tile so they read
+   as floating ledges, not chunks of detached floor.
+3. Hand-painted lantern falloff — replace the `GradientTexture2D`
+   placeholder with a painterly radial falloff. Pure art swap, no
+   gameplay change.
+
+---
+
 ## 2026-05-17 — Tighten the agentic loop
 
 **Shipped**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -3,6 +3,7 @@ _Last updated: 2026-05-17_
 
 ## Live loop
 Hub.tscn ↔ Realm1 (cave traversal) ↔ Hub return. Door 1 wired.
+Realm 1 exit plays a one-line lore moment before the fade.
 Door 2 / Door 3: stubs.
 
 ## What is wired
@@ -12,28 +13,33 @@ Door 2 / Door 3: stubs.
 - Tilemap floor + platforms in Realm 1 (brown-cave palette)
 - Door interact (Y key) → scene transition with fade
 - Hub respawn at the door Curiosity returned through
+- **LoreMoment overlay** (`scenes/UI/LoreMoment.tscn` + `scripts/LoreMoment.gd`) —
+  reusable single-line lore display: slow fade-in / hold / fade-out, soft
+  serif via SystemFont fallback, no box. Wired into `Door.exit_lore_line`
+  so any realm exit can set its own beat. Realm 1 exit uses it.
 - Touch controls scene (mobile / touch-browser)
-- GitHub Pages auto-deploy on merge to main
+- GitHub Pages auto-deploy on merge to main (live build at
+  https://nex2406.github.io/curiositys-doors/)
 
 ## What exists but is unwired
 - Combat / dash / lever / approach / hurt / charged / celebrate animations
   on Curiosity (frames imported, not reachable from state machine)
-- Save system, dialogue overlay, puzzle framework (all docs-only)
+- Save system, puzzle framework (docs-only)
 - Hand-painted lantern falloff (still gradient placeholder)
 - Cloak / eye-blink / fog shaders
 - Per-realm ambient audio
 
 ## Last session
-[2026-05-17 — Tighten the agentic loop](SESSIONS.md#2026-05-17--tighten-the-agentic-loop)
+[2026-05-17 — Realm 1 lore moment + LoreMoment scene](SESSIONS.md#2026-05-17--realm-1-lore-moment--loremoment-scene)
 
 ## Next 3 safe candidates
-1. **Realm 1 lore moment (queued spec)** — one short Curiosity-voice line
-   on Realm 1 exit before the fade. Local to the realm, no global dialogue
-   framework needed yet.
-2. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
+1. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
    tracked in a global singleton, hub-side "forge the key" moment on
    return. Foundation for the Realm 1 → Door 2 unlock loop.
-3. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
+2. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
    the solid sub-floor block. A peak-top platform tile (e.g. row-22
    rocky-band coords) would read more as a floating ledge than a chunk
    of detached floor.
+3. **Hand-painted lantern falloff** — replace the `GradientTexture2D`
+   placeholder with a painterly radial falloff. Pure art swap, no
+   gameplay change.

--- a/scenes/UI/LoreMoment.tscn
+++ b/scenes/UI/LoreMoment.tscn
@@ -1,0 +1,43 @@
+; Reusable lore-moment overlay. See scripts/LoreMoment.gd for behavior.
+;
+; Soft serif via SystemFont fallback chain — picks the host serif when
+; available, falls back to Godot default if running in a browser without
+; the requested fonts. A bundled .ttf is the planned polish follow-up.
+
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/LoreMoment.gd" id="1_lore"]
+
+[sub_resource type="SystemFont" id="SystemFont_serif"]
+font_names = PackedStringArray("Georgia", "Times New Roman", "DejaVu Serif", "Liberation Serif", "serif")
+antialiasing = 1
+hinting = 1
+subpixel_positioning = 1
+
+[node name="LoreMoment" type="CanvasLayer"]
+layer = 100
+script = ExtResource("1_lore")
+
+[node name="Container" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+
+[node name="Line" type="Label" parent="Container"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -500.0
+offset_top = -60.0
+offset_right = 500.0
+offset_bottom = 60.0
+theme_override_colors/font_color = Color(0.96, 0.91, 0.78, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 0.85)
+theme_override_constants/outline_size = 6
+theme_override_fonts/font = SubResource("SystemFont_serif")
+theme_override_font_sizes/font_size = 36
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+text = ""

--- a/scenes/realms/Realm1.tscn
+++ b/scenes/realms/Realm1.tscn
@@ -161,6 +161,7 @@ target_realm = "hub"
 door_id = "Realm1Exit"
 prompt_offset = Vector2(0, -110)
 prompt_text = "[Y] Return"
+exit_lore_line = "The dark grew careful where her lantern had been."
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ExitDoor/DoorArea"]
 shape = SubResource("RectangleShape2D_exitdoor")

--- a/scripts/Door.gd
+++ b/scripts/Door.gd
@@ -16,6 +16,11 @@ signal left_door(door)
 @export_group("Prompt")
 @export var prompt_offset: Vector2 = Vector2(0, -120)
 @export var prompt_text: String = "[Y] Enter"
+@export_group("Lore")
+## Optional single-line lore moment that plays before the transition fade.
+## Leave empty to skip. Used by realm exits to land an environmental beat
+## right before returning to the hub. See scripts/LoreMoment.gd.
+@export_multiline var exit_lore_line: String = ""
 
 const _PROMPT_SIZE: Vector2 = Vector2(140, 30)
 const _PROMPT_COLOR: Color = Color(1.0, 0.93, 0.66, 0.95)
@@ -116,7 +121,26 @@ func trigger() -> void:
 		Transition.last_door_id = door_id
 	# Hold the flash briefly so the player sees the Y register before fade.
 	await get_tree().create_timer(_TRIGGER_TO_FADE_DELAY).timeout
+	if exit_lore_line.strip_edges() != "":
+		await _play_lore(exit_lore_line)
 	await Transition.transition_to(path)
+
+
+func _play_lore(text: String) -> void:
+	# Instantiate a fresh LoreMoment overlay under the current scene, await
+	# its full fade-in / hold / fade-out cycle, and let it free itself.
+	var lore_scene: PackedScene = load("res://scenes/UI/LoreMoment.tscn")
+	if lore_scene == null:
+		push_warning("[Door] LoreMoment scene missing — skipping lore line")
+		return
+	var lore: Node = lore_scene.instantiate()
+	var host: Node = get_tree().current_scene
+	if host == null:
+		push_warning("[Door] No current scene to host LoreMoment — skipping")
+		return
+	host.add_child(lore)
+	if lore.has_method("play_line"):
+		await lore.play_line(text)
 
 
 static func _resolve_scene_path(target: String) -> String:

--- a/scripts/LoreMoment.gd
+++ b/scripts/LoreMoment.gd
@@ -1,0 +1,36 @@
+extends CanvasLayer
+
+# Reusable lore-moment overlay. Spawn one of these as a child of the
+# current scene, call `play_line(text)`, await — it fades in, holds,
+# fades out, and frees itself. Use it whenever a single short line of
+# environmental narration should land before a scene transition. Every
+# realm uses this; Door.gd is the primary caller.
+#
+# Per docs/VIBE.md the line should be short, sparse, melancholic, and
+# never didactic. Per docs/MECHANICS.md "Dialogue / Lore Overlay" the
+# presentation rules are: no boxes, no portraits, no ticking crawl —
+# just text that fades in slowly, holds, fades out.
+
+@export var fade_in_time: float = 1.0
+@export var hold_time: float = 3.0
+@export var fade_out_time: float = 1.0
+
+@onready var _label: Label = $Container/Line
+
+
+func _ready() -> void:
+	_label.modulate.a = 0.0
+
+
+# Plays one line. Awaitable — callers can `await lore.play_line(text)`
+# and continue once the fade-out completes and this node is freed.
+func play_line(text: String) -> void:
+	_label.text = text
+	var tween: Tween = create_tween()
+	tween.tween_property(_label, "modulate:a", 1.0, fade_in_time) \
+		.set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+	tween.tween_interval(hold_time)
+	tween.tween_property(_label, "modulate:a", 0.0, fade_out_time) \
+		.set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+	await tween.finished
+	queue_free()


### PR DESCRIPTION
## Summary
- New reusable \`LoreMoment\` overlay (\`scenes/UI/LoreMoment.tscn\` + \`scripts/LoreMoment.gd\`): single-line lore display with slow fade-in / hold / fade-out, centered, no box, no portrait, soft serif via \`SystemFont\` fallback. Awaitable from any caller.
- \`Door.gd\` extended with \`exit_lore_line\` — any door can set a line that plays before the transition fade. Realm 1's exit uses it. Every future realm will use it.
- The line: **\"The dark grew careful where her lantern had been.\"** — lantern-anchored imagery from the book, \"grew careful\" implies the cave reacted without narrating it did, past tense gives after-presence.

Closes #66.

## What's in the diff
| File | Change |
| --- | --- |
| \`scripts/LoreMoment.gd\` | **new** — controller (play_line + tween + queue_free) |
| \`scenes/UI/LoreMoment.tscn\` | **new** — CanvasLayer + centered Label + SystemFont serif chain |
| \`scripts/Door.gd\` | + \`exit_lore_line\` export; \`trigger()\` awaits LoreMoment before Transition |
| \`scenes/realms/Realm1.tscn\` | ExitDoor sets \`exit_lore_line\` |
| \`docs/STATE.md\` | LoreMoment → wired; Live loop notes the lore beat; Next 3 re-ranked |
| \`docs/MECHANICS.md\` | LoreMoment in Implemented; Dialogue Overlay trimmed in Planned; lore moment removed from Next Safe Candidates |
| \`docs/SESSIONS.md\` | 2026-05-17 entry appended |

## Test plan
- [ ] \`godot --headless --import\` passes (CI verifies)
- [ ] \`godot --headless --export-release \"Web\" build/index.html\` passes (CI verifies)
- [ ] Played on live build at https://nex2406.github.io/curiositys-doors/
  - [ ] Walk Curiosity to Realm 1 exit door, press Y
  - [ ] Line fades in slowly (~1s), holds (~3s), fades out (~1s), then the existing transition fade plays
  - [ ] No double-fade, no overlap, no skip
  - [ ] Line renders centered, serif-leaning, warm cream over the cave
- [ ] docs/STATE.md updated this session ✓
- [ ] docs/SESSIONS.md entry appended this session ✓

## Kill criteria
- [ ] Revert if the line reads as cute, loud, or expository — per brief. Specifically: revert if it tells the player what to feel, names the cave's awareness directly, uses exclamation, or makes Advika cringe on first read. **The system stays; only the line text is in scope for revert.** Worst-case revert path is the one-line tweak in \`scenes/realms/Realm1.tscn\`, not the whole LoreMoment scene.

## Known follow-ups (not in this PR)
- Bundle a free-license painterly serif \`.ttf\` to replace the \`SystemFont\` fallback chain (queued in MECHANICS.md Next Safe Feature Candidates).
- Multi-line dialogue + in-realm trigger zones (queued in MECHANICS.md Planned, builds on the same overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)