### PR TITLE
chore: close the agentic loop — self-referential docs + durable session prompt

### DIFF
--- a/.github/ISSUE_TEMPLATE/art.md
+++ b/.github/ISSUE_TEMPLATE/art.md
@@ -32,6 +32,8 @@ labels: ["art"]
 - [ ] Wired into the target scene
 - [ ] Web export still passes
 - [ ] Looks like a painting in the running game, not a placeholder
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session
 
 ## Kill criteria
 <!-- Revert if X by Y. One bullet. Forces the "what would make me

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -27,3 +27,11 @@ labels: ["bug"]
 - [ ] p1 — visible to anyone who plays
 - [ ] p2 — edge case or polish gap
 - [ ] p3 — cosmetic, low impact
+
+## Acceptance
+- [ ] Root cause identified (not just symptom patched)
+- [ ] `godot --headless --import` passes
+- [ ] `godot --headless --export-release "Web" build/index.html` passes
+- [ ] Verified on the live site after merge
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -24,6 +24,8 @@ labels: ["feat"]
 - [ ] No regression in feel or performance
 - [ ] Adheres to docs/ART_DIRECTION.md and docs/VIBE.md
 - [ ] CLAUDE.md / docs/ updated if conventions changed
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session
 
 ## Kill criteria
 <!-- Revert if X by Y. One bullet. Forces the "what would make me

--- a/.github/ISSUE_TEMPLATE/realm.md
+++ b/.github/ISSUE_TEMPLATE/realm.md
@@ -39,8 +39,9 @@ labels: ["realm"]
 - [ ] No regression in feel or performance
 - [ ] Adheres to docs/ART_DIRECTION.md and docs/VIBE.md
 - [ ] Realm entry registered in `Door.gd::_resolve_scene_path`
-- [ ] docs/STATE.md "Live loop" and "What is wired" updated
 - [ ] docs/REALMS.md entry promoted from drafted → in-build or shipped
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session
 
 ## Kill criteria
 <!-- Revert if X by Y. One bullet. Forces the "what would make me

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -23,3 +23,5 @@ labels: ["research"]
 - [ ] Question answered with a concrete recommendation
 - [ ] Tradeoffs listed (what we give up by choosing this path)
 - [ ] Linked follow-up issues filed (feat / art / story) if the answer unlocks build work
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -23,3 +23,5 @@ labels: ["story"]
 - [ ] Verbs of stillness preferred (holds, lingers, listens, recognizes)
 - [ ] Reads aloud cleanly at a slow cadence
 - [ ] Integrates into the relevant scene without a UI box
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,8 @@ Closes #
 - [ ] Played on the live site after merge OR verified in a local web export
 - [ ] No regression in visuals, performance, or feel
 - [ ] CLAUDE.md / docs/ updated if conventions changed
+- [ ] docs/STATE.md updated this session
+- [ ] docs/SESSIONS.md entry appended this session
 
 ## Screenshots / clips
 <!-- Required for any visual change. Stills preferred for atmosphere; short clips for motion or audio. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Curiosity's Doors
 
+> Every session starts by pasting [`docs/SESSION_PROMPT.md`](docs/SESSION_PROMPT.md).
+
 ## North Star
 "Curiosity's Doors" is a 2D side-scrolling atmospheric puzzle game.
 - ONE hero: Curiosity — cloaked traveler, glowing lantern, blinking-eye cloak pattern, face hidden.
@@ -97,3 +99,16 @@ The design lives in `INTENT.md`, `docs/realms/*`, and `docs/SKETCHBOOK.md`. It g
 - **At session end**, ask: *"Anything new today we should write down before we close?"* Capture it.
 
 No interrogation. One open question at the right moments. The brain grows by listening, not by quizzing.
+
+---
+
+## See also
+
+- [`docs/STATE.md`](docs/STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](docs/SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](docs/VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](docs/MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](docs/REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](docs/ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](docs/STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](docs/VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/ART_DIRECTION.md
+++ b/docs/ART_DIRECTION.md
@@ -60,3 +60,16 @@ Each realm shifts the palette without abandoning it. A realm may push toward blu
 
 ## What This Looks Like When Done Right
 A still frame from any moment in the game should be screenshotable, frameable, and *quiet*. If a screenshot looks like a screenshot, we missed. It should look like a painting that's holding its breath.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/MECHANICS.md
+++ b/docs/MECHANICS.md
@@ -229,3 +229,16 @@ none of these require designing a new system from scratch.
    gameplay change.
 5. **Painterly serif `.ttf` for LoreMoment** — bundle a free-license
    serif so the lore overlay stops depending on host-system fonts.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/REALMS.md
+++ b/docs/REALMS.md
@@ -76,3 +76,16 @@ Use this template for every new realm. Fill it in before writing any scene code.
 - A realm of small things (scale shifts, intimacy)
 
 These are not committed. Open an issue to promote one to drafted.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -7,6 +7,52 @@ Format: `date | what shipped | what didn't work | next 3 safe candidates`
 
 ---
 
+## 2026-05-17 — Close the agentic loop
+
+**Shipped**
+- `docs/SESSION_PROMPT.md` — the durable single-paste session opener.
+  Names the protocol, the queue, the template choice, the acceptance
+  bar, and the 3-line end-of-session report. From now on, one paste
+  starts every session.
+- `CLAUDE.md` carries a one-line banner directly under the title
+  pointing at `SESSION_PROMPT.md`. The brain points at itself.
+- **Self-referential docs**: `## See also` footer added to each of
+  `CLAUDE.md`, `docs/STATE.md`, `docs/SESSIONS.md`, `docs/VISION.md`,
+  `docs/MECHANICS.md`, `docs/REALMS.md`, `docs/ART_DIRECTION.md`,
+  `docs/STORY.md`, `docs/VIBE.md`. Each footer lists the other 8 with
+  one-line roles. Open any doc → see the whole map.
+- `.github/PULL_REQUEST_TEMPLATE.md` + every issue template
+  (feat / bug / art / story / research / realm) now require two new
+  checkboxes in Acceptance: `docs/STATE.md updated this session` and
+  `docs/SESSIONS.md entry appended this session`. The discipline is in
+  the templates, not in someone's head.
+- `bug.md` gained an Acceptance section it never had — root-cause +
+  import/export green + live verification + the two new STATE/SESSIONS
+  checkboxes.
+- `docs/STATE.md` Next 3 re-ranked: item 1 is now
+  **"Realm 2 — design + build (use realm.md)"**.
+- For SESSIONS.md specifically: a note explains that new entries are
+  inserted *above* the See also footer so the footer stays permanent.
+
+**What didn't work / dead ends**
+- None this session — pure docs / scaffolding work, no code paths
+  exercised. The Phase 2 lore-moment PR was the live-build test for
+  the new loop and it landed green.
+
+**Next 3 safe candidates**
+1. Realm 2 — design + build (use realm.md). Interview Advika for all
+   5 template fields (theme word, palette refs, puzzle premise, lore
+   beat on exit, what player carries forward), then build. Do not
+   invent answers.
+2. Realm 1 jade-piece pickups — scattered collectible nodes, counter
+   tracked in a global singleton, hub-side "forge the key" moment on
+   return. Foundation for the Realm 1 → Door 2 unlock loop.
+3. Hand-painted lantern falloff — replace the `GradientTexture2D`
+   placeholder with a painterly radial falloff. Pure art swap, no
+   gameplay change.
+
+---
+
 ## 2026-05-17 — Realm 1 lore moment + LoreMoment scene
 
 **Shipped**
@@ -184,3 +230,20 @@ Format: `date | what shipped | what didn't work | next 3 safe candidates`
 3. Audit the parallax cave painting against the brown-cave foreground — the deepest layer
    is still a cool blue-grey while the tiles are warm brown. Subtle but the tonal split
    shows when there's an exposed gap.
+
+---
+
+> **Note for future appenders:** new session entries are inserted **above** the See also
+> footer (between the most recent entry and the footer), keeping the footer permanently at
+> the bottom of the file.
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/SESSION_PROMPT.md
+++ b/docs/SESSION_PROMPT.md
@@ -1,0 +1,26 @@
+---
+# Curiosity's Doors — Session Prompt
+Paste this at the start of every Claude Code session.
+
+Follow CLAUDE.md "Session Start Protocol."
+Pick item 1 from docs/STATE.md "Next 3 safe candidates."
+Build it:
+  - NEW REALM → use realm.md template. Interview Advika
+    for all 5 fields before building. Do not invent
+    answers.
+  - FEAT / BUG / ART / STORY / RESEARCH → use the
+    matching template. Fill every field including Kill
+    criteria.
+Ship one PR closing the issue. Acceptance:
+  - godot --headless --import passes
+  - godot --headless --export-release "Web" build passes
+  - Played on live build
+  - No regression
+  - docs/STATE.md updated
+  - docs/SESSIONS.md appended (shipped / didn't work /
+    next 3)
+End-of-session report (3 lines):
+  1. Shipped (PR # + live link)
+  2. Didn't (and why)
+  3. Top of Next 3 now
+---

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -30,16 +30,29 @@ Door 2 / Door 3: stubs.
 - Per-realm ambient audio
 
 ## Last session
-[2026-05-17 — Realm 1 lore moment + LoreMoment scene](SESSIONS.md#2026-05-17--realm-1-lore-moment--loremoment-scene)
+[2026-05-17 — Close the agentic loop](SESSIONS.md#2026-05-17--close-the-agentic-loop)
 
 ## Next 3 safe candidates
-1. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
+1. **Realm 2 — design + build (use `realm.md`)** — interview Advika for
+   all 5 template fields (theme word, palette refs, puzzle premise, lore
+   beat on exit, what player carries forward), then build. Do not invent
+   answers.
+2. **Realm 1 jade-piece pickups** — scattered collectible nodes, counter
    tracked in a global singleton, hub-side "forge the key" moment on
    return. Foundation for the Realm 1 → Door 2 unlock loop.
-2. **Polish pass on platform rocks** — `T_PLATFORM_L/M/R` currently reuse
-   the solid sub-floor block. A peak-top platform tile (e.g. row-22
-   rocky-band coords) would read more as a floating ledge than a chunk
-   of detached floor.
 3. **Hand-painted lantern falloff** — replace the `GradientTexture2D`
    placeholder with a painterly radial falloff. Pure art swap, no
    gameplay change.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/STORY.md
+++ b/docs/STORY.md
@@ -50,3 +50,16 @@ The first door is closer than they thought.
 - Sentences short. Paragraphs sparse. White space is part of the writing.
 - No exclamations. No questions directed at the player. No "you must."
 - Verbs of stillness preferred: *holds, lingers, waits, listens, recognizes*. Verbs of action sparingly.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing

--- a/docs/VIBE.md
+++ b/docs/VIBE.md
@@ -56,3 +56,16 @@ Before merging anything that touches player-visible content, ask:
 - If a player took a screenshot, would they want to keep it?
 
 If any answer falters, hold the change.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/VISION.md`](VISION.md) — north star: hero, hub, realms, the three bars (visual / technical / narrative)
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -24,3 +24,16 @@ Each realm is small, hand-built, and committed. No procedural content. A realm i
 
 ## The Promise to the Player
 You will not be rushed. You will not be scored. You will be invited inward. The doors remember you even if you do not remember them.
+
+---
+
+## See also
+
+- [`CLAUDE.md`](../CLAUDE.md) — repo-wide engineering guide; Quality Gate; Session Start Protocol
+- [`docs/STATE.md`](STATE.md) — single living snapshot of what's wired right now; updated every session
+- [`docs/SESSIONS.md`](SESSIONS.md) — append-only build log: shipped / didn't / next 3 per session
+- [`docs/MECHANICS.md`](MECHANICS.md) — engineering reference: implemented vs planned systems
+- [`docs/REALMS.md`](REALMS.md) — per-realm spec: theme, palette, soundscape, puzzle mechanic, lore reveal
+- [`docs/ART_DIRECTION.md`](ART_DIRECTION.md) — painterly bible: palette hexes, lighting model, scale rules
+- [`docs/STORY.md`](STORY.md) — narrative scaffolding: plot beats, tonal constraints, voice rules
+- [`docs/VIBE.md`](VIBE.md) — tone allow/deny lists; sanity check before naming or writing


### PR DESCRIPTION
## Summary
The final loop-closing PR. After this lands, **one paste of \`docs/SESSION_PROMPT.md\` starts every future session** — no more drift, no more re-deriving where we are.

- New \`docs/SESSION_PROMPT.md\` — durable session opener. Names the protocol, the queue (STATE.md), the template choice (realm vs feat/bug/art/story/research), the acceptance bar, and the 3-line end-of-session report.
- \`CLAUDE.md\` banner under the title points at it.
- **Self-referential \`## See also\` footers** on all 9 core docs (CLAUDE / STATE / SESSIONS / VISION / MECHANICS / REALMS / ART_DIRECTION / STORY / VIBE). Open any one, see the whole map.
- \`STATE.md\` updated this session + \`SESSIONS.md\` appended (and the new PR template + every issue template now enforce both).
- STATE.md Next 3 re-ranked: item 1 = **Realm 2 — design + build**.

## What's in the diff
| File | Change |
| --- | --- |
| \`docs/SESSION_PROMPT.md\` | **new** — single-paste session opener |
| \`CLAUDE.md\` | + banner under title; + See also footer |
| \`docs/STATE.md\` | Next 3 re-ranked (Realm 2 → item 1); Last session pointer updated; + See also footer |
| \`docs/SESSIONS.md\` | Phase 3 entry appended; note about insert-above-footer pattern; + See also footer |
| \`docs/VISION.md\` | + See also footer |
| \`docs/MECHANICS.md\` | + See also footer |
| \`docs/REALMS.md\` | + See also footer |
| \`docs/ART_DIRECTION.md\` | + See also footer |
| \`docs/STORY.md\` | + See also footer |
| \`docs/VIBE.md\` | + See also footer |
| \`.github/PULL_REQUEST_TEMPLATE.md\` | + 2 Verification checkboxes (STATE / SESSIONS) |
| \`.github/ISSUE_TEMPLATE/feat.md\` | + 2 Acceptance checkboxes |
| \`.github/ISSUE_TEMPLATE/art.md\` | + 2 Acceptance checkboxes |
| \`.github/ISSUE_TEMPLATE/bug.md\` | + Acceptance section (previously had none) with root-cause + import/export + live + 2 new checkboxes |
| \`.github/ISSUE_TEMPLATE/story.md\` | + 2 Acceptance checkboxes |
| \`.github/ISSUE_TEMPLATE/research.md\` | + 2 Acceptance checkboxes |
| \`.github/ISSUE_TEMPLATE/realm.md\` | + 2 Acceptance checkboxes |

## Verification
- [ ] \`godot --headless --import\` passes (CI verifies — docs-only change, but per Quality Gate)
- [ ] \`godot --headless --export-release \"Web\" build/index.html\` passes (CI verifies)
- [ ] Played on the live site after merge OR verified in a local web export — N/A, docs-only
- [ ] No regression in visuals, performance, or feel — N/A
- [ ] CLAUDE.md / docs/ updated if conventions changed ✓
- [ ] docs/STATE.md updated this session ✓
- [ ] docs/SESSIONS.md entry appended this session ✓

## Kill criteria
- [ ] Revert if: the See also footers introduce drift faster than they reduce it (e.g. someone updates one footer but forgets the other 8 and the maps go stale). Fix would be a script that regenerates all 9 footers from a single source-of-truth list, not a revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)