### PR TITLE
fix(realm1): grey bottom band + Curiosity scale

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -64,3 +64,7 @@ interact={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
+
+[rendering]
+
+environment/defaults/default_clear_color=Color(0.043, 0.063, 0.078, 1)

--- a/scenes/Hub.tscn
+++ b/scenes/Hub.tscn
@@ -233,6 +233,6 @@ process_material = SubResource("ParticleProcessMaterial_firefly_hub")
 
 [node name="Curiosity" parent="." instance=ExtResource("1_curiosity")]
 position = Vector2(640, 580)
-scale = Vector2(0.5, 0.5)
+scale = Vector2(0.4, 0.4)
 
 [node name="TouchControls" parent="." instance=ExtResource("2_touch")]

--- a/scenes/realms/Realm1.tscn
+++ b/scenes/realms/Realm1.tscn
@@ -81,43 +81,43 @@ script = ExtResource("3_realm1")
 
 [node name="BG1" type="ParallaxLayer" parent="ParallaxBackground"]
 motion_scale = Vector2(0.1, 0)
-motion_mirroring = Vector2(1440, 0)
+motion_mirroring = Vector2(1536, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/BG1"]
 texture_filter = 1
 centered = false
 texture = ExtResource("5_bg1")
-scale = Vector2(1.5, 1.5)
+scale = Vector2(1.6, 1.6)
 
 [node name="BG2" type="ParallaxLayer" parent="ParallaxBackground"]
 motion_scale = Vector2(0.25, 0)
-motion_mirroring = Vector2(1440, 0)
+motion_mirroring = Vector2(1536, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/BG2"]
 texture_filter = 1
 centered = false
 texture = ExtResource("6_bg2")
-scale = Vector2(1.5, 1.5)
+scale = Vector2(1.6, 1.6)
 
 [node name="BG3" type="ParallaxLayer" parent="ParallaxBackground"]
 motion_scale = Vector2(0.45, 0)
-motion_mirroring = Vector2(1440, 0)
+motion_mirroring = Vector2(1536, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/BG3"]
 texture_filter = 1
 centered = false
 texture = ExtResource("7_bg3")
-scale = Vector2(1.5, 1.5)
+scale = Vector2(1.6, 1.6)
 
 [node name="BG4" type="ParallaxLayer" parent="ParallaxBackground"]
 motion_scale = Vector2(0.7, 0)
-motion_mirroring = Vector2(1440, 0)
+motion_mirroring = Vector2(1536, 0)
 
 [node name="Sprite" type="Sprite2D" parent="ParallaxBackground/BG4"]
 texture_filter = 1
 centered = false
 texture = ExtResource("8_bg4")
-scale = Vector2(1.5, 1.5)
+scale = Vector2(1.6, 1.6)
 
 [node name="CanvasModulate" type="CanvasModulate" parent="."]
 color = Color(0.72, 0.68, 0.66, 1)
@@ -131,7 +131,7 @@ scale = Vector2(2, 2)
 
 [node name="Curiosity" parent="." instance=ExtResource("1_curiosity")]
 position = Vector2(160, 1300)
-scale = Vector2(0.5, 0.5)
+scale = Vector2(0.4, 0.4)
 
 [node name="ExitDoor" type="Node2D" parent="."]
 position = Vector2(7520, 544)

--- a/scripts/Realm1.gd
+++ b/scripts/Realm1.gd
@@ -297,13 +297,21 @@ func _pick(variants: Array[Vector2i]) -> Vector2i:
 # ─── actor placement ─────────────────────────────────────────────────────
 func _position_curiosity() -> void:
 	# Floor in chunk 1 sits at tile y=22 → top edge at world y=1408.
-	# Curiosity body half-height = 108 (rect 88x432 at scene scale 0.5).
-	# Place her so the body bottom rests exactly on the floor top.
+	# Place Curiosity so their body bottom rests just above the floor top.
+	# Half-height is derived from the collision shape × the instance scale so
+	# this stays correct if Curiosity is rescaled (currently 0.4).
 	var floor_top_world: float = 22.0 * float(VISUAL_TILE)
 	_curiosity.position = Vector2(
 		float(SPAWN_TILE.x) * float(VISUAL_TILE) + float(VISUAL_TILE) * 0.5,
-		floor_top_world - 108.0
+		floor_top_world - _curiosity_half_height()
 	)
+
+
+func _curiosity_half_height() -> float:
+	var shape_node: CollisionShape2D = _curiosity.get_node_or_null("CollisionShape2D") as CollisionShape2D
+	if shape_node and shape_node.shape is RectangleShape2D:
+		return (shape_node.shape as RectangleShape2D).size.y * 0.5 * _curiosity.scale.y
+	return 100.0 * _curiosity.scale.y
 
 
 func _position_exit_door() -> void:


### PR DESCRIPTION
Closes #71.

- **Grey line**: dark cave `default_clear_color` so uncovered pixels read deep-cave instead of grey, plus parallax scale 1.5→1.6 (mirroring 1440→1536) to overflow the viewport bottom.
- **Curiosity scale**: 0.5→0.4 in Realm 1 and Hub (consistent). Spawn half-height now derived from the collision shape × scale.

Verified: godot 4.6.2 `--headless --import` + `--export-release Web` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)