### PR TITLE
feat(mobile): harden web shell for touch players

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -26,7 +26,7 @@ vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
 html/custom_html_shell=""
-html/head_include=""
+html/head_include="<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover'><meta name='mobile-web-app-capable' content='yes'><meta name='apple-mobile-web-app-capable' content='yes'><meta name='apple-mobile-web-app-status-bar-style' content='black-translucent'><style>html,body{margin:0;padding:0;width:100%;height:100%;overflow:hidden;background:#0b1014;overscroll-behavior:none}*{touch-action:none;-webkit-tap-highlight-color:transparent;-webkit-touch-callout:none;-webkit-user-select:none;user-select:none}</style>"
 html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
 html/experimental_virtual_keyboard=false


### PR DESCRIPTION
Closes #73.

Injects mobile meta + CSS via the Web preset `head_include`:
- viewport locked (no pinch-zoom, `viewport-fit=cover` for notches)
- mobile/apple web-app-capable + translucent status bar
- CSS kills page scroll, overscroll/pull-to-refresh, tap-highlight, text-select; dark loading bg
Pairs with existing touch controls, adaptive canvas, landscape orientation.

Verified: `--export-release Web` clean; meta confirmed in generated index.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)