### PR TITLE
feat(realm1): warm 'Crimson Hollow' ember mood + living lantern

### DIFF
--- a/docs/SKETCHBOOK.md
+++ b/docs/SKETCHBOOK.md
@@ -9,6 +9,19 @@ Rules:
 
 ---
 
+## 2026-06-09
+
+- **Realm 1 mood: cold → warm.** Tried a cool blue-grey ambient `(0.34,0.36,0.44)`
+  for "moody dark cave." Advika didn't connect with it. A throwaway debug test
+  cranked the tint hard red — Advika immediately loved it. Because
+  `CanvasModulate` *multiplies* the teal cave art, even a bold red reads as a
+  warm **ember** glow, not alarm: rocks go orange, the water stays cold teal,
+  Curiosity glows like a coal in the split. Landed on `(0.9,0.2,0.2)`. This
+  pulls Realm 1 back to its canon name — **The Crimson Hollow** — which the
+  cool blue had quietly drifted away from. Lesson: the warm accent wants a warm
+  *world* to live in here, not a cold one to fight. Lantern also now breathes
+  (cast-light energy flicker on two out-of-phase sines) so the pool feels alive.
+
 ## 2026-06-08
 
 - **Combat & bosses are in scope.** Advika: each realm is its own dimension,

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,5 +1,5 @@
 # Current State (auto-narrative — update at end of every session)
-_Last updated: 2026-05-17_
+_Last updated: 2026-06-09_
 
 ## Live loop
 Hub.tscn ↔ Realm1 (cave traversal) ↔ Hub return. Door 1 wired.
@@ -8,9 +8,12 @@ Door 2 / Door 3: stubs.
 
 ## What is wired
 - Curiosity locomotion: idle / walk / run / jump / air / land
-- Lantern PointLight2D with placeholder gradient + soft flame flicker
+- Lantern PointLight2D with placeholder gradient + soft flame flicker;
+  cast-light energy also breathes (two out-of-phase sines) so the warm pool
+  feels alive while idle
 - Parallax in Hub + Realm 1
-- Tilemap floor + platforms in Realm 1 (brown-cave palette)
+- Tilemap floor + platforms in Realm 1 — warm ember "Crimson Hollow" ambient
+  `(0.9, 0.2, 0.2)`: orange-lit rock, cold teal water, lantern as the focal coal
 - Door interact (Y key) → scene transition with fade
 - Hub respawn at the door Curiosity returned through
 - **LoreMoment overlay** (`scenes/UI/LoreMoment.tscn` + `scripts/LoreMoment.gd`) —

--- a/scenes/Curiosity.tscn
+++ b/scenes/Curiosity.tscn
@@ -225,10 +225,10 @@ shape = SubResource("RectangleShape2D_body")
 
 [node name="Lantern" type="PointLight2D" parent="."]
 position = Vector2(-160, 115)
-color = Color(1, 0.86, 0.33, 1)
-energy = 3.8
+color = Color(1, 0.85, 0.4, 1)
+energy = 4.4
 texture = ExtResource("56_lantern_halo")
-texture_scale = 7.0
+texture_scale = 10.0
 
 [node name="Camera" type="Camera2D" parent="."]
 position = Vector2(0, -160)

--- a/scenes/realms/Realm1.tscn
+++ b/scenes/realms/Realm1.tscn
@@ -120,7 +120,7 @@ texture = ExtResource("8_bg4")
 scale = Vector2(1.6, 1.6)
 
 [node name="CanvasModulate" type="CanvasModulate" parent="."]
-color = Color(0.72, 0.68, 0.66, 1)
+color = Color(0.9, 0.2, 0.2, 1)
 
 [node name="World" type="Node2D" parent="."]
 scale = Vector2(2, 2)

--- a/scripts/Curiosity.gd
+++ b/scripts/Curiosity.gd
@@ -25,6 +25,13 @@ const MOVE_EPSILON: float = 8.0
 const FLAME_FLICKER_AMPLITUDE: float = 0.05
 const FLAME_FLICKER_PERIOD: float = 0.4
 
+# The cast light breathes too — two out-of-phase sines give an organic,
+# non-mechanical flicker instead of a steady pulse.
+const LIGHT_FLICKER_FAST: float = 0.4
+const LIGHT_FLICKER_SLOW: float = 0.17
+const LIGHT_FLICKER_FAST_AMP: float = 0.12
+const LIGHT_FLICKER_SLOW_AMP: float = 0.06
+
 # Source art faces LEFT. Default unflipped = facing left.
 var _state: State = State.IDLE
 var _facing_right: bool = false
@@ -33,6 +40,7 @@ var _lantern_tween: Tween
 var _was_airborne: bool = false
 var _flame_time: float = 0.0
 var _flame_base_alpha: float = 1.0
+var _lantern_base_energy: float = 1.0
 
 
 func _ready() -> void:
@@ -42,6 +50,7 @@ func _ready() -> void:
 	lantern.position.x = anchor_x
 	flame.position.x = anchor_x
 	_flame_base_alpha = flame.modulate.a
+	_lantern_base_energy = lantern.energy
 	visual.animation_finished.connect(_on_animation_finished)
 	visual.play(&"idle")
 
@@ -50,6 +59,11 @@ func _process(delta: float) -> void:
 	_flame_time += delta
 	var flicker: float = sin(_flame_time * TAU / FLAME_FLICKER_PERIOD) * FLAME_FLICKER_AMPLITUDE
 	flame.modulate.a = clampf(_flame_base_alpha + flicker, 0.0, 1.0)
+	# Cast light breathes with the flame so the warm pool feels alive.
+	var energy_flicker: float = \
+		sin(_flame_time * TAU / LIGHT_FLICKER_FAST) * LIGHT_FLICKER_FAST_AMP \
+		+ sin(_flame_time * TAU / LIGHT_FLICKER_SLOW) * LIGHT_FLICKER_SLOW_AMP
+	lantern.energy = _lantern_base_energy * (1.0 + energy_flicker)
 
 
 func _physics_process(delta: float) -> void:


### PR DESCRIPTION
## What
Realm 1's ambient tint had drifted to a cool blue-grey that read as a generic dark cave. This swaps it to a bold red `CanvasModulate` `(0.9, 0.2, 0.2)` — which, because it *multiplies* the existing teal cave art, renders as warm **ember** rock over cold teal water, with the gold lantern as the focal coal. Pulls Realm 1 back to its canon **"Crimson Hollow"** identity (per `docs/SKETCHBOOK.md`).

The lantern also feels alive now:
- cast-light energy **breathes** on two out-of-phase sines — organic flicker, not a mechanical pulse
- warmer + brighter halo, scaled 7 → 10 so the warm pool reaches into the dark

## Why
Advika A/B'd the cool-blue vs warm-ember look live; the ember won decisively and matches the realm's intended mood + the art bible's "ember orange warm accent" rule. Net: more visually appealing, no gameplay/perf change.

## Quality gate
- `godot --headless --import` — clean (exit 0)
- `godot --headless --export-release "Web" build/index.html` — clean (exit 0, `index.html` produced)
- A/B'd against prior live look (warm-grey) — deliberate, intended visual improvement

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)