### PR TITLE
fix(hub): upward-only door bob so doors never clip the floor

### DIFF
--- a/scripts/Hub.gd
+++ b/scripts/Hub.gd
@@ -84,8 +84,11 @@ func _process(delta: float) -> void:
 func _animate_bob(delta: float) -> void:
 	_bob_time += delta
 	for i in _door_roots.size():
-		var offset: float = sin(_bob_time * TAU / _BOB_PERIOD + _door_phase[i]) * _BOB_AMPLITUDE
-		_door_roots[i].position.y = _door_base_y[i] + offset
+		# Upward-only bob: remap sin's -1..1 to 0..1 so the door floats between
+		# its resting Y (lowest, on the floor) and base_y - amplitude (highest).
+		# It never crosses below base_y, so the bases never clip into the floor.
+		var rise: float = (sin(_bob_time * TAU / _BOB_PERIOD + _door_phase[i]) * 0.5 + 0.5) * _BOB_AMPLITUDE
+		_door_roots[i].position.y = _door_base_y[i] - rise
 
 
 func _update_active_door() -> void:


### PR DESCRIPTION
## Problem
The levitating hub doors used a symmetric sine bob (`base_y + sin·amplitude`), so on the downward half they dipped ~18px below their resting Y and clipped into the floor.

## Fix
Upward-only bob: `(sin·0.5 + 0.5)` remaps sin's −1..1 → 0..1, so the door floats strictly between `base_y` (resting on the floor, lowest) and `base_y − amplitude` (highest). It only ever rises — never crosses below base into the floor. Amplitude (18px), period (3.5s), and per-door phase offset unchanged; label + interaction collision still ride the bob.

```gdscript
var rise = (sin(_bob_time * TAU / _BOB_PERIOD + _door_phase[i]) * 0.5 + 0.5) * _BOB_AMPLITUDE
_door_roots[i].position.y = _door_base_y[i] - rise
```

## Quality gate
- `godot --headless --import` — clean (exit 0)
- `godot --headless --export-release "Web"` — clean (exit 0, `index.html` produced)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)