### PR TITLE
fix(display): resolution-independent hub framing (keep aspect, 1920x1080 base)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -25,10 +25,10 @@ config_version=5
 
 [display]
 
-window/size/viewport_width=1280
-window/size/viewport_height=720
+window/size/viewport_width=1920
+window/size/viewport_height=1080
 window/stretch/mode="canvas_items"
-window/stretch/aspect="expand"
+window/stretch/aspect="keep"
 window/handheld/orientation="sensor_landscape"
 
 [input]

--- a/scenes/Hub.tscn
+++ b/scenes/Hub.tscn
@@ -284,7 +284,7 @@ scale = Vector2(0.38, 0.38)
 
 [node name="Camera" parent="Curiosity" index="4"]
 position = Vector2(0, -790)
-zoom = Vector2(0.45, 0.45)
+zoom = Vector2(0.675, 0.675)
 
 [node name="Vignette" type="CanvasLayer" parent="."]
 layer = 1


### PR DESCRIPTION
## Problem
At browser fullscreen the character and doors became huge and the composition cropped in. Cause: `window/stretch/aspect="expand"` — a larger canvas reveals *more world* instead of scaling the 1280×720 design, so the framing changed with window size.

## Fix
- **Base resolution:** 1280×720 → **1920×1080** (clean 16:9 design canvas).
- **Stretch:** mode `canvas_items` (unchanged) + aspect `expand` → **`keep`** — Godot now scales the whole design *uniformly* to any window/fullscreen, letterboxing off-16:9 screens instead of distorting/cropping.
- **Camera zoom:** Hub-only override `0.45 → 0.675` (×1.5) so the visible world matches the taller base (`720/0.45 = 1080/0.675 = 1600` world-units) — framing identical to the approved composition.
- Web `canvas_resize_policy=2` (Adaptive) left as-is (already correct).

## Verified
Rendered at 1920×1080, 2560×1440 (bigger 16:9), and 1920×1200 (non-16:9) — **identical composition** every time; the non-16:9 gets thin dark letterbox bars. No crop, no giant character.

## Quality gate
- `godot --headless --import` — clean (exit 0)
- `godot --headless --export-release "Web"` — clean (exit 0, `index.html` produced)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)