### PR TITLE
feat(intro): low rolling ground fog on Cauldron 2

### DIFF
--- a/scripts/IntroEffects.gd
+++ b/scripts/IntroEffects.gd
@@ -180,9 +180,28 @@ func _particles(gi: int, pos: Vector2, cfg: Dictionary) -> void:
 	_groups[gi].add_child(p)
 
 
-# 1 — CAULDRON 2: misty forest brew. Rising white-teal smoke, ground smoke-ring
-# shimmer, warm cauldron-emblem glow, a few drifting embers.
+# 1 — CAULDRON 2: misty forest brew. Low rolling ground fog, rising white-teal
+# smoke, ground smoke-ring shimmer, warm cauldron-emblem glow, drifting embers.
 func _build_cauldron(gi: int) -> void:
+	# Low ground-level fog drifting horizontally (left -> right) across the
+	# lower third — large soft puffs, low opacity. Added first so it sits
+	# behind the smoke/embers/glow. Particles fade via the colour ramp, so the
+	# drift is endless with no loop seam.
+	_particles(gi, _n(0.5, 0.82), {
+		"amount": 12, "lifetime": 12.0, "tex": "halo",
+		"rect": Vector2(1100, 120), "dir": Vector2(1, 0), "spread": 8.0,
+		"grav": Vector2(0, -1), "vmin": 8.0, "vmax": 18.0,
+		"smin": 1.8, "smax": 3.4, "color": Color(0.78, 0.93, 0.92, 0.08),
+		"life_rand": 0.5,
+	})
+	# Faint second wisp, a touch higher and faster, for depth.
+	_particles(gi, _n(0.5, 0.72), {
+		"amount": 8, "lifetime": 15.0, "tex": "halo",
+		"rect": Vector2(1100, 90), "dir": Vector2(1, 0), "spread": 6.0,
+		"grav": Vector2(0, -1), "vmin": 14.0, "vmax": 26.0,
+		"smin": 1.4, "smax": 2.6, "color": Color(0.8, 0.94, 0.93, 0.05),
+		"life_rand": 0.5,
+	})
 	_particles(gi, _n(0.42, 0.45), {
 		"amount": 16, "lifetime": 5.0, "tex": "halo",
 		"dir": Vector2(0, -1), "spread": 14.0, "grav": Vector2(0, -6),


### PR DESCRIPTION
Adds horizontal drifting ground mist to the Cauldron 2 background only, in addition to the existing rising smoke, embers, and hero glow (all unchanged).

- Two CPUParticles2D layers of large soft white-teal halo puffs, low opacity (~0.08 ground, ~0.05 wisp), drifting left -> right across the lower third.
- Ground fog band at (0.5, 0.82); a fainter, slightly higher and faster wisp at (0.5, 0.72) for parallax depth.
- Particles fade via their colour ramp, so the drift is endless with no loop seam. Added behind the smoke/embers/glow.
- Runs only while Cauldron 2 is active (children of the Cauldron effect group, paused by the existing set_active logic). Other backgrounds untouched.

**Verified locally**
- `godot --headless --import` -> exit 0.
- Headless scene run (150 frames) -> exit 0, no script errors.
- `godot --headless --export-release "Web"` -> exit 0.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)