### PR TITLE
feat(engine): Dialogue service — one-call awaitable Curiosity speech (M1)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 SaveManager="*res://scripts/SaveManager.gd"
+Dialogue="*res://scripts/Dialogue.gd"
 Transition="*res://scripts/SceneTransition.gd"
 
 [configuration]

--- a/scripts/Dialogue.gd
+++ b/scripts/Dialogue.gd
@@ -1,0 +1,48 @@
+extends Node
+
+# Autoload "Dialogue" — the one-call entry point for making Curiosity speak.
+#
+# DialogueBox.tscn already owns the look + typewriter + advance logic. This
+# service wraps it so any scene can run a sequence without hand-embedding the
+# box and wiring signals: just `await Dialogue.say([...])`, which resolves once
+# the player has dismissed the final line.
+#
+#   func _on_something() -> void:
+#       await Dialogue.say(["A line.", "Another line."])
+#       # ...continues here after the box closes.
+#
+# One dialogue runs at a time (overlapping calls are ignored, not queued) — the
+# foundation guarantees a single active box; sequencing/queuing can layer on top
+# later if a realm needs it. Content lives with the caller; this owns plumbing.
+
+signal started   # emitted as a sequence begins
+signal closed    # emitted after the box is dismissed and freed
+
+const BOX_SCENE: PackedScene = preload("res://scenes/UI/DialogueBox.tscn")
+
+var _box: CanvasLayer = null
+
+
+func is_active() -> bool:
+	return _box != null
+
+
+# Play `lines` in order. Awaitable: the coroutine resumes after the last line
+# is advanced past and the box has freed itself. `speaker` labels the box;
+# defaults to Curiosity, the only voice for now.
+func say(lines: Array, speaker: String = "Curiosity") -> void:
+	if lines.is_empty():
+		return
+	if _box != null:
+		push_warning("[Dialogue] say() ignored — a dialogue is already active")
+		return
+	_box = BOX_SCENE.instantiate()
+	# Export var set before add_child so the box's _ready picks up the speaker.
+	_box.speaker_name = speaker
+	get_tree().root.add_child(_box)
+	emit_signal("started")
+	_box.start(lines)
+	await _box.finished
+	_box.queue_free()
+	_box = null
+	emit_signal("closed")

--- a/scripts/Dialogue.gd.uid
+++ b/scripts/Dialogue.gd.uid
@@ -1,0 +1,1 @@
+uid://4es72efsrytk

--- a/tests/test_dialogue.gd
+++ b/tests/test_dialogue.gd
@@ -1,0 +1,74 @@
+extends SceneTree
+
+# Headless check for the Dialogue service.
+#   godot --headless --script res://tests/test_dialogue.gd
+# Drives a full multi-line sequence through the autoload script deterministically
+# (advancing the box programmatically rather than via real input/timing), and
+# confirms it opens, steps every line, resolves the awaitable, and tears down.
+
+const DialogueScript := preload("res://scripts/Dialogue.gd")
+
+
+func _initialize() -> void:
+	# Defer one frame so root exists, then run the async body.
+	_run.call_deferred()
+
+
+func _run() -> void:
+	var fails: int = 0
+	var dlg: Node = DialogueScript.new()
+	root.add_child(dlg)
+
+	var closed_count: Array = [0]
+	var started_count: Array = [0]
+	dlg.closed.connect(func() -> void: closed_count[0] += 1)
+	dlg.started.connect(func() -> void: started_count[0] += 1)
+
+	fails += _check("idle before say()", not dlg.is_active())
+
+	var lines: Array = ["Test line one.", "Test line two.", "Test line three."]
+	dlg.say(lines)   # fire-and-forget coroutine
+
+	fails += _check("active after say()", dlg.is_active())
+	fails += _check("started emitted once", started_count[0] == 1)
+
+	# Track that every line gets surfaced.
+	var lines_seen: Array = [0]
+	var box: CanvasLayer = dlg._box
+	if box != null:
+		box.line_changed.connect(func(_i: int) -> void: lines_seen[0] += 1)
+
+	# Drive: each _on_advance_pressed() either finishes typing or advances; two
+	# presses retire one line. Re-fetch the box each step since it frees itself
+	# the instant the final line is dismissed.
+	var safety: int = 0
+	while dlg.is_active() and safety < 64:
+		var active_box: CanvasLayer = dlg._box
+		if active_box == null:
+			break
+		active_box._on_advance_pressed()
+		await process_frame
+		safety += 1
+
+	fails += _check("idle after sequence", not dlg.is_active())
+	fails += _check("closed emitted once", closed_count[0] == 1)
+	# line_changed(0) fires inside start() before our connect, so we observe the
+	# two later lines being entered (>=2 proves it stepped past the first).
+	fails += _check("stepped through later lines", lines_seen[0] >= 2)
+	fails += _check("did not run away", safety < 64)
+
+	# Empty input is a no-op, not a crash.
+	dlg.say([])
+	fails += _check("empty say() stays idle", not dlg.is_active())
+
+	if fails == 0:
+		print("[test_dialogue] ALL PASSED")
+		quit(0)
+	else:
+		print("[test_dialogue] FAILED: %d check(s)" % fails)
+		quit(1)
+
+
+func _check(label: String, ok: bool) -> int:
+	print(("  PASS " if ok else "  FAIL ") + label)
+	return 0 if ok else 1

--- a/tests/test_dialogue.gd.uid
+++ b/tests/test_dialogue.gd.uid
@@ -1,0 +1,1 @@
+uid://babxquk8kqg5j

--- a/tests/test_save_manager.gd.uid
+++ b/tests/test_save_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://ciedlrrmac543


### PR DESCRIPTION
## What
Second brick of **Milestone 1 — Core engine foundations**: a `Dialogue` autoload that turns the existing `DialogueBox` into a reusable *system*.

`DialogueBox.tscn/.gd` already had the full typewriter / multi-line / advance logic, but it was only hand-embedded in the Intro and driven bespoke. Now any scene can do:

```gdscript
await Dialogue.say(["A line.", "Another line."])
# resumes here once the player dismisses the last line
```

## API
- `say(lines, speaker = "Curiosity")` — awaitable; resolves on dismissal
- `is_active()`, `started` / `closed` signals
- One dialogue at a time (overlapping calls ignored, not queued)

## Scope discipline
- Reuses `DialogueBox.tscn` unchanged → **Intro untouched**, no visual change.
- **No canonical Curiosity dialogue authored.** Content stays with callers (Advika writes the lines). The service is proven with placeholder text in a headless test only; real in-game moments wire up once lines exist.

## Verification
- ✅ `--import` clean (exit 0)
- ✅ `--export-release "Web"` clean (exit 0, `Dialogue.gd.remap` packed)
- ✅ Headless test (`tests/test_dialogue.gd`) drives a full 3-line sequence through the service — 8/8: opens, steps each line, resolves the awaitable, fires `started`/`closed` once, tears down, empty `say([])` is a safe no-op.

Closes #104