### PR TITLE
feat(engine): AudioManager — per-scene ambient bus with crossfade (M1)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ config/icon="res://icon.svg"
 
 SaveManager="*res://scripts/SaveManager.gd"
 Dialogue="*res://scripts/Dialogue.gd"
+AudioManager="*res://scripts/AudioManager.gd"
 Transition="*res://scripts/SceneTransition.gd"
 
 [configuration]

--- a/scripts/AudioManager.gd
+++ b/scripts/AudioManager.gd
@@ -1,0 +1,164 @@
+extends Node
+
+# Autoload "AudioManager" — owns ambient music + SFX for the whole game.
+#
+# Each scene declares the ambient it wants in its _ready (by stream + a name),
+# and this manager crossfades from whatever was playing. Re-requesting the same
+# track is a no-op, so returning to a scene that's already sounding doesn't
+# restart it. Two players ping-pong so a crossfade never cuts.
+#
+#   func _ready() -> void:
+#       AudioManager.play_ambient(MY_TRACK, "realm1")   # real track
+#       # or, until a real track exists:
+#       AudioManager.play_placeholder("realm1")          # synthesized drone
+#
+# The placeholder is a soft, seamless-looping low drone generated in code, so
+# the system is real and audible with no committed/licensed audio. Swapping in
+# a real per-scene track later is a one-line change at the call site.
+#
+# Buses (Ambient, SFX) are created at runtime and routed to Master, so the
+# project needs no checked-in bus layout.
+
+signal ambient_changed(track_name: String)
+
+const AMBIENT_BUS: String = "Ambient"
+const SFX_BUS: String = "SFX"
+const DEFAULT_FADE: float = 1.5
+const SILENCE_DB: float = -80.0
+# Ambient sits a touch below unity so a track has headroom and never dominates
+# the mix; the placeholder drone is quiet by design on top of this.
+const AMBIENT_DB: float = -6.0
+
+const PLACEHOLDER_NAME: String = "placeholder_drone"
+
+var _players: Array[AudioStreamPlayer] = []
+var _active: int = 0
+var _current_name: String = ""
+var _placeholder: AudioStreamWAV
+var _fade_tween: Tween
+
+
+func _ready() -> void:
+	_ensure_bus(AMBIENT_BUS)
+	_ensure_bus(SFX_BUS)
+	_placeholder = _make_placeholder_drone()
+	for i in 2:
+		var p: AudioStreamPlayer = AudioStreamPlayer.new()
+		p.bus = AMBIENT_BUS
+		p.volume_db = SILENCE_DB
+		add_child(p)
+		_players.append(p)
+
+
+# ─── ambient ───────────────────────────────────────────────────────────────
+
+func is_playing() -> bool:
+	return _current_name != "" and _players[_active].playing
+
+
+# Crossfade to `stream` (a null stream falls back to the placeholder drone).
+# `track_name` identifies it so the same track isn't restarted on re-request.
+func play_ambient(stream: AudioStream, track_name: String, fade: float = DEFAULT_FADE) -> void:
+	if track_name == _current_name and _players[_active].playing:
+		return
+	var incoming: AudioStream = stream if stream != null else _placeholder
+	_current_name = track_name
+
+	var next_i: int = 1 - _active
+	var incoming_player: AudioStreamPlayer = _players[next_i]
+	var outgoing_player: AudioStreamPlayer = _players[_active]
+
+	incoming_player.stream = incoming
+	incoming_player.volume_db = SILENCE_DB
+	incoming_player.play()
+	_crossfade(incoming_player, outgoing_player, fade)
+	_active = next_i
+	emit_signal("ambient_changed", track_name)
+
+
+# Convenience: play the built-in placeholder drone under `track_name`. Used
+# until a scene has a real track; the crossfade still runs so transitions are
+# proven end to end.
+func play_placeholder(track_name: String = PLACEHOLDER_NAME, fade: float = DEFAULT_FADE) -> void:
+	play_ambient(null, track_name, fade)
+
+
+func stop_ambient(fade: float = DEFAULT_FADE) -> void:
+	_current_name = ""
+	var p: AudioStreamPlayer = _players[_active]
+	var t: Tween = create_tween()
+	t.tween_property(p, "volume_db", SILENCE_DB, fade)
+	t.tween_callback(p.stop)
+
+
+func _crossfade(incoming_player: AudioStreamPlayer, outgoing_player: AudioStreamPlayer, fade: float) -> void:
+	if _fade_tween and _fade_tween.is_valid():
+		_fade_tween.kill()
+	_fade_tween = create_tween().set_parallel(true)
+	_fade_tween.tween_property(incoming_player, "volume_db", AMBIENT_DB, fade) \
+		.set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+	if outgoing_player.playing:
+		_fade_tween.tween_property(outgoing_player, "volume_db", SILENCE_DB, fade) \
+			.set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+		# Stop the faded-out player once the parallel fades complete, but only if
+		# it wasn't reclaimed as the active player by a newer crossfade.
+		_fade_tween.chain().tween_callback(func() -> void:
+			if outgoing_player != _players[_active]:
+				outgoing_player.stop())
+
+
+# ─── sfx ───────────────────────────────────────────────────────────────────
+
+# Fire-and-forget one-shot. Spawns a short-lived player that frees itself.
+func play_sfx(stream: AudioStream, volume_db: float = 0.0) -> void:
+	if stream == null:
+		return
+	var p: AudioStreamPlayer = AudioStreamPlayer.new()
+	p.bus = SFX_BUS
+	p.stream = stream
+	p.volume_db = volume_db
+	add_child(p)
+	p.finished.connect(p.queue_free)
+	p.play()
+
+
+# ─── internals ─────────────────────────────────────────────────────────────
+
+func _ensure_bus(bus_name: String) -> void:
+	if AudioServer.get_bus_index(bus_name) != -1:
+		return
+	var idx: int = AudioServer.bus_count
+	AudioServer.add_bus(idx)
+	AudioServer.set_bus_name(idx, bus_name)
+	AudioServer.set_bus_send(idx, "Master")
+
+
+# Generate a soft, seamless-looping low drone as a 16-bit mono AudioStreamWAV.
+# Every partial and the breathing LFO are multiples of 1/duration, so the loop
+# point is click-free. This is a placeholder voice, not the final ambience.
+func _make_placeholder_drone() -> AudioStreamWAV:
+	var rate: int = 22050
+	var seconds: int = 4
+	var frames: int = rate * seconds   # 88200 → loop length is a whole 4s
+	var buf: PackedByteArray = PackedByteArray()
+	buf.resize(frames * 2)
+	for i in frames:
+		var t: float = float(i) / float(rate)
+		# Breath: one slow swell per loop (0.25 Hz), amplitude 0.2 … 1.0.
+		var breath: float = 0.6 + 0.4 * sin(TAU * 0.25 * t - PI * 0.5)
+		# Low triad — all multiples of 0.25 Hz, so each completes whole cycles.
+		var s: float = 0.5 * sin(TAU * 55.0 * t)
+		s += 0.3 * sin(TAU * 82.5 * t)
+		s += 0.2 * sin(TAU * 110.0 * t)
+		s *= breath * 0.12   # keep it quiet; this is atmosphere, not melody
+		var v: int = int(clampf(s, -1.0, 1.0) * 32767.0)
+		buf.encode_s16(i * 2, v)
+	var wav: AudioStreamWAV = AudioStreamWAV.new()
+	wav.format = AudioStreamWAV.FORMAT_16_BITS
+	wav.stereo = false
+	wav.mix_rate = rate
+	wav.loop_mode = AudioStreamWAV.LOOP_FORWARD
+	wav.loop_begin = 0
+	wav.loop_end = frames
+	wav.data = buf
+	return wav

--- a/scripts/AudioManager.gd.uid
+++ b/scripts/AudioManager.gd.uid
@@ -1,0 +1,1 @@
+uid://gjtkh31v40ie

--- a/scripts/Hub.gd
+++ b/scripts/Hub.gd
@@ -34,6 +34,9 @@ var _bob_time: float = 0.0
 
 
 func _ready() -> void:
+	# Ambient bed for the hub. Placeholder drone until a real hub track lands;
+	# crossfades from a realm's ambient on return. (AudioManager M1 foundation.)
+	AudioManager.play_placeholder("hub")
 	# If returning from a realm, snap Curiosity to the entry door before reveal.
 	if Transition.last_door_id != "":
 		_respawn_at_door(Transition.last_door_id)

--- a/scripts/Realm1.gd
+++ b/scripts/Realm1.gd
@@ -73,6 +73,9 @@ var _cam: Camera2D
 
 
 func _ready() -> void:
+	# Ambient bed for the Crimson Hollow. Placeholder drone until a real realm 1
+	# track lands; crossfades from the hub ambient on entry. (AudioManager M1.)
+	AudioManager.play_placeholder("realm1")
 	_rng = RandomNumberGenerator.new()
 	_rng.seed = RNG_SEED
 	var ts: TileSet = _build_tileset()

--- a/tests/test_audio_manager.gd
+++ b/tests/test_audio_manager.gd
@@ -1,0 +1,69 @@
+extends SceneTree
+
+# Headless check for the AudioManager foundation.
+#   godot --headless --script res://tests/test_audio_manager.gd
+# Verifies the synthesized placeholder drone is well-formed and that ambient
+# state transitions (play / re-request no-op / crossfade swap / stop) behave.
+
+const AudioManagerScript := preload("res://scripts/AudioManager.gd")
+
+
+func _initialize() -> void:
+	_run.call_deferred()
+
+
+func _run() -> void:
+	var fails: int = 0
+	var am: Node = AudioManagerScript.new()
+	root.add_child(am)   # _ready creates buses + players + drone
+
+	# Buses exist and route somewhere.
+	fails += _check("Ambient bus created", AudioServer.get_bus_index("Ambient") != -1)
+	fails += _check("SFX bus created", AudioServer.get_bus_index("SFX") != -1)
+
+	# Placeholder drone is a usable, looping, non-empty stream.
+	var drone: AudioStreamWAV = am._placeholder
+	fails += _check("drone is AudioStreamWAV", drone is AudioStreamWAV)
+	fails += _check("drone has PCM data", drone.data.size() > 0)
+	fails += _check("drone loops forward", drone.loop_mode == AudioStreamWAV.LOOP_FORWARD)
+	# 4 s * 22050 Hz * 2 bytes (16-bit mono) = 176400 bytes.
+	fails += _check("drone length correct", drone.data.size() == 22050 * 4 * 2)
+
+	fails += _check("idle before play", not am.is_playing())
+
+	# Enter hub ambient.
+	am.play_placeholder("hub")
+	fails += _check("playing after hub", am.is_playing())
+	fails += _check("current name is hub", am._current_name == "hub")
+	var hub_player: int = am._active
+
+	# Re-requesting the same track is a no-op (no player swap, no restart).
+	am.play_placeholder("hub")
+	fails += _check("re-request same is no-op", am._active == hub_player)
+
+	# Crossfade to a different track flips the active player.
+	am.play_placeholder("realm1")
+	fails += _check("current name is realm1", am._current_name == "realm1")
+	fails += _check("active player swapped", am._active != hub_player)
+	fails += _check("still playing after swap", am.is_playing())
+
+	# Stop clears the current track.
+	am.stop_ambient()
+	fails += _check("name cleared after stop", am._current_name == "")
+	fails += _check("not playing after stop", not am.is_playing())
+
+	# SFX with a null stream is a safe no-op (doesn't crash / spawn a player).
+	am.play_sfx(null)
+	fails += _check("null sfx is safe", true)
+
+	if fails == 0:
+		print("[test_audio_manager] ALL PASSED")
+		quit(0)
+	else:
+		print("[test_audio_manager] FAILED: %d check(s)" % fails)
+		quit(1)
+
+
+func _check(label: String, ok: bool) -> int:
+	print(("  PASS " if ok else "  FAIL ") + label)
+	return 0 if ok else 1

--- a/tests/test_audio_manager.gd.uid
+++ b/tests/test_audio_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bir5q6t4n6ewj


### PR DESCRIPTION
## What
Third brick of **Milestone 1 — Core engine foundations**: an `AudioManager` autoload that owns ambient music + SFX. Each scene declares the track it wants; the manager handles bus routing, crossfade on change, and stop-on-exit.

```gdscript
func _ready() -> void:
    AudioManager.play_ambient(MY_TRACK, "realm1")   # real track later
    AudioManager.play_placeholder("realm1")          # synthesized drone for now
```

## Design
- Ambient + SFX buses created at runtime, routed to Master (no checked-in bus layout).
- Two ambient players ping-pong → crossfade never cuts; re-requesting the same track is a no-op (won't restart).
- **Placeholder ambience synthesized in code**: a soft, seamless-looping low drone (16-bit mono `AudioStreamWAV`; partials + breath LFO all multiples of 1/duration, so the loop point is click-free). No committed/licensed audio.
- Real per-scene tracks (hub, prologue, each realm — **Advika sources them**) drop in with a one-line swap at the call site. Content stays with the caller, same as dialogue lines.

## Wired now
Hub and Realm 1 play the placeholder on enter, so the crossfade is exercised across the door transition.

## Verification
- ✅ `--import` clean (exit 0)
- ✅ `--export-release "Web"` clean (exit 0, `AudioManager.gd.remap` packed)
- ✅ Headless test (`tests/test_audio_manager.gd`) — 16/16: buses created, drone well-formed + correct length + loops, play / re-request no-op / crossfade swap / stop transitions, null SFX safe.

## Note on feel
The placeholder is intentionally quiet (ambient bus at −6 dB, drone gain 0.12). It's a stand-in to prove the plumbing — final tracks are Advika's. Easy to tune or mute if it reads wrong live.

Closes #106