### PR TITLE
feat(engine): RealmBase template + TestRealm — closes M1 foundations

### DIFF
--- a/scenes/realms/TestRealm.tscn
+++ b/scenes/realms/TestRealm.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=2 format=3 uid="uid://b0testrealm0m1x"]
+
+[ext_resource type="Script" path="res://scripts/TestRealm.gd" id="1_testrealm"]
+
+[node name="TestRealm" type="Node2D"]
+script = ExtResource("1_testrealm")
+realm_id = "test_realm"
+ambient_name = "test_realm"
+exit_lore_line = "A door is only a question you have not yet asked."
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="BG" type="ColorRect" parent="UI"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.043, 0.051, 0.082, 1)
+
+[node name="Label" type="Label" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -360.0
+offset_top = -120.0
+offset_right = 360.0
+offset_bottom = -20.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.9, 0.91, 0.96, 1)
+theme_override_font_sizes/font_size = 40
+text = "TestRealm"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Tokens" type="HBoxContainer" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -120.0
+offset_top = 40.0
+offset_right = 120.0
+offset_bottom = 88.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 24
+alignment = 1
+
+[node name="Dot0" type="ColorRect" parent="UI/Tokens"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.22, 0.2, 0.26, 1)
+
+[node name="Dot1" type="ColorRect" parent="UI/Tokens"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.22, 0.2, 0.26, 1)
+
+[node name="Dot2" type="ColorRect" parent="UI/Tokens"]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+color = Color(0.22, 0.2, 0.26, 1)

--- a/scripts/RealmBase.gd
+++ b/scripts/RealmBase.gd
@@ -1,0 +1,93 @@
+extends Node2D
+class_name RealmBase
+
+# The template every realm builds on. It owns the cross-cutting plumbing common
+# to all realms — ambient audio on enter, marking the realm visited, restoring
+# saved realm state, lore-on-exit, and the trip back to the hub — so a concrete
+# realm only fills in its own content through the three hooks below.
+#
+# A realm = a Node2D scene whose root script `extends RealmBase`, with:
+#   realm_id        set (its save namespace + default ambient key)
+#   _on_realm_ready() overridden for scene setup (runs after audio + restore)
+#   capture_state() / apply_state() overridden to persist its own progress
+# and calling exit_to_hub() when the player leaves.
+#
+# Realm 1 predates this and is intentionally NOT retrofitted here (that's M3);
+# this template is for realms 2/3 and the throwaway TestRealm.
+
+@export var realm_id: String = ""
+## AudioManager track key. Defaults to realm_id when left blank.
+@export var ambient_name: String = ""
+## Optional real ambient stream. Null → AudioManager's placeholder drone.
+@export var ambient_track: AudioStream = null
+## Optional single line shown before the fade home (see LoreMoment).
+@export_multiline var exit_lore_line: String = ""
+@export var return_scene: String = "res://scenes/Hub.tscn"
+
+var _exiting: bool = false
+
+
+func _ready() -> void:
+	var key: String = ambient_name if ambient_name != "" else realm_id
+	AudioManager.play_ambient(ambient_track, key)
+	if realm_id != "":
+		SaveManager.set_flag("visited_%s" % realm_id, true)
+	_apply_saved_state()
+	_on_realm_ready()
+
+
+# ─── hooks for subclasses ──────────────────────────────────────────────────
+
+# Scene setup, after ambient has started and saved state has been applied.
+func _on_realm_ready() -> void:
+	pass
+
+
+# Return this realm's persistable progress. Shape is the realm's own business.
+func capture_state() -> Dictionary:
+	return {}
+
+
+# Restore from a dictionary previously returned by capture_state().
+func apply_state(_data: Dictionary) -> void:
+	pass
+
+
+# ─── save plumbing ─────────────────────────────────────────────────────────
+
+# Persist the realm's current state. Call whenever progress changes.
+func save_realm() -> void:
+	if realm_id == "":
+		return
+	SaveManager.set_realm_state(realm_id, capture_state())
+
+
+func _apply_saved_state() -> void:
+	if realm_id == "":
+		return
+	var data: Dictionary = SaveManager.get_realm_state(realm_id)
+	if not data.is_empty():
+		apply_state(data)
+
+
+# ─── exit ──────────────────────────────────────────────────────────────────
+
+func exit_to_hub() -> void:
+	if _exiting:
+		return
+	_exiting = true
+	save_realm()
+	if exit_lore_line.strip_edges() != "":
+		await _play_lore(exit_lore_line)
+	await Transition.transition_to(return_scene)
+
+
+func _play_lore(text: String) -> void:
+	var lore_scene: PackedScene = load("res://scenes/UI/LoreMoment.tscn")
+	if lore_scene == null:
+		push_warning("[RealmBase] LoreMoment scene missing — skipping exit lore")
+		return
+	var lore: Node = lore_scene.instantiate()
+	add_child(lore)
+	if lore.has_method("play_line"):
+		await lore.play_line(text)

--- a/scripts/RealmBase.gd.uid
+++ b/scripts/RealmBase.gd.uid
@@ -1,0 +1,1 @@
+uid://be0vhoux3kb35

--- a/scripts/SaveManager.gd
+++ b/scripts/SaveManager.gd
@@ -10,6 +10,7 @@ extends Node
 #   doors_opened : Array[String]        # door_ids the player has entered
 #   inventory    : Dictionary           # item_name -> int count
 #   flags        : Dictionary           # arbitrary named bool/value flags
+#   realms       : Dictionary           # realm_id -> that realm's saved state
 #
 # Persistence: JSON at user://. On the HTML5 build user:// is backed by the
 # browser's IndexedDB, which Godot 4 flushes on file close — so a save written
@@ -114,6 +115,25 @@ func get_flag(name: String, default_value: Variant = false) -> Variant:
 	return (_state["flags"] as Dictionary).get(name, default_value)
 
 
+# ─── per-realm state ───────────────────────────────────────────────────────
+# Each realm owns an opaque dictionary of its own progress (tokens collected,
+# levers pulled, etc.). RealmBase reads/writes this; the shapes are the realm's
+# business, not SaveManager's.
+
+func set_realm_state(realm_id: String, data: Dictionary) -> void:
+	if realm_id == "":
+		return
+	(_state["realms"] as Dictionary)[realm_id] = data.duplicate(true)
+	save_game()
+
+
+func get_realm_state(realm_id: String) -> Dictionary:
+	var realms: Dictionary = _state["realms"]
+	if realms.has(realm_id) and realms[realm_id] is Dictionary:
+		return (realms[realm_id] as Dictionary).duplicate(true)
+	return {}
+
+
 # ─── internals ─────────────────────────────────────────────────────────────
 
 func _default_state() -> Dictionary:
@@ -122,6 +142,7 @@ func _default_state() -> Dictionary:
 		"doors_opened": [],
 		"inventory": {},
 		"flags": {},
+		"realms": {},
 	}
 
 
@@ -137,3 +158,5 @@ func _merge_into_state(loaded: Dictionary) -> void:
 		_state["inventory"] = (loaded["inventory"] as Dictionary).duplicate()
 	if loaded.has("flags") and loaded["flags"] is Dictionary:
 		_state["flags"] = (loaded["flags"] as Dictionary).duplicate()
+	if loaded.has("realms") and loaded["realms"] is Dictionary:
+		_state["realms"] = (loaded["realms"] as Dictionary).duplicate(true)

--- a/scripts/TestRealm.gd
+++ b/scripts/TestRealm.gd
@@ -1,0 +1,45 @@
+extends RealmBase
+
+# Throwaway proving ground for the RealmBase foundation — NOT a shipped realm.
+# Demonstrates the full M1 loop in one screen: enter via RealmBase (ambient +
+# visited flag + state restore), change state ([Y] collects a token), persist
+# it, and exit home ([S]/down) via RealmBase. Relaunching shows the collected
+# count restored — the in-realm proof that SaveManager survives a restart.
+
+const TOKEN_COUNT: int = 3
+
+var _collected: int = 0
+
+@onready var _label: Label = $UI/Label
+@onready var _tokens: HBoxContainer = $UI/Tokens
+
+
+func _on_realm_ready() -> void:
+	_refresh()
+
+
+func capture_state() -> Dictionary:
+	return {"collected": _collected}
+
+
+func apply_state(data: Dictionary) -> void:
+	_collected = clampi(int(data.get("collected", 0)), 0, TOKEN_COUNT)
+
+
+func _process(_delta: float) -> void:
+	if _exiting:
+		return
+	if Input.is_action_just_pressed("interact") and _collected < TOKEN_COUNT:
+		_collected += 1
+		save_realm()
+		_refresh()
+	elif Input.is_action_just_pressed("move_down"):
+		exit_to_hub()
+
+
+func _refresh() -> void:
+	_label.text = "TestRealm — collected %d / %d\n[Y] collect    [S / ↓] exit to hub" % [_collected, TOKEN_COUNT]
+	for i in _tokens.get_child_count():
+		var dot: ColorRect = _tokens.get_child(i) as ColorRect
+		if dot:
+			dot.color = Color(0.92, 0.78, 0.46, 1.0) if i < _collected else Color(0.22, 0.2, 0.26, 1.0)

--- a/scripts/TestRealm.gd.uid
+++ b/scripts/TestRealm.gd.uid
@@ -1,0 +1,1 @@
+uid://bsvc1hu1lby84

--- a/tests/test_save_manager.gd
+++ b/tests/test_save_manager.gd
@@ -39,6 +39,14 @@ func _initialize() -> void:
 	sm3.load_game()
 	fails += _check("dedupe: no duplicate door entry", sm3.is_door_opened("Door1"))
 
+	# Per-realm state round-trips and stays isolated per realm.
+	fails += _check("realm: empty before write", sm3.get_realm_state("test_realm").is_empty())
+	sm3.set_realm_state("test_realm", {"collected": 2})
+	var sm4: Node = SaveManagerScript.new()
+	sm4.load_game()
+	fails += _check("realm: state persisted", int(sm4.get_realm_state("test_realm").get("collected", 0)) == 2)
+	fails += _check("realm: other realm untouched", sm4.get_realm_state("realm_9").is_empty())
+
 	# Cleanup so a real game boots fresh.
 	sm.reset()
 


### PR DESCRIPTION
## What
Fourth and final brick of **Milestone 1 — Core engine foundations**: the `RealmBase` template every future realm inherits, plus a throwaway `TestRealm` that proves the whole M1 loop end to end.

`RealmBase` (class_name) owns the plumbing common to all realms:
- ambient audio on enter (via AudioManager)
- marks the realm visited (SaveManager flag)
- restores saved realm state
- optional lore line before the fade home
- `exit_to_hub()` → save + lore + transition

A concrete realm only overrides three hooks: `_on_realm_ready()`, `capture_state()`, `apply_state()`.

`SaveManager` gains per-realm opaque state (`set_realm_state` / `get_realm_state`) — the namespace each realm persists its progress under.

## TestRealm (throwaway — not shipped, not reachable from the game)
One screen that exercises everything: enter via RealmBase → `[Y]` collects a token (persisted immediately) → `[S]`/down exits home via RealmBase. **Relaunch shows the collected count restored** — the in-realm proof that SaveManager survives a restart, ticking the last open M1 done-when.

## Scope discipline
Realm 1 is **not** retrofitted onto RealmBase — that's M3 (Realm 1 to ship-quality). This template is for realms 2/3 + the test room.

## Verification
- ✅ `--import` clean (exit 0)
- ✅ `--export-release "Web"` clean (exit 0; RealmBase / TestRealm packed)
- ✅ SaveManager realm-state round-trip in `tests/test_save_manager.gd` — 12/12 (persists across a fresh instance; realms stay isolated)
- ✅ Headless scene smoke: `--quit-after 120 TestRealm.tscn` with real autoloads → exit 0, no script errors (RealmBase enter path runs clean)

## M1 status
This closes the milestone's four foundation systems: **SaveManager ✓ · Dialogue ✓ · AudioManager ✓ · RealmBase ✓**.

Closes #108