### PR TITLE
chore: dev shortcut to reach TestRealm on the live build

### DIFF
--- a/scripts/Hub.gd
+++ b/scripts/Hub.gd
@@ -84,6 +84,15 @@ func _process(delta: float) -> void:
 		_current_door.trigger()
 
 
+# TEMP (testing): press T to jump into the throwaway TestRealm, so the M1
+# save/restore loop is reachable on the live build without a shipped door.
+# Invisible (no art/text). Remove once M2 has its own test arena. See issue #110.
+func _unhandled_key_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.pressed and not event.echo \
+			and (event as InputEventKey).keycode == KEY_T:
+		Transition.transition_to("res://scenes/realms/TestRealm.tscn")
+
+
 func _animate_bob(delta: float) -> void:
 	_bob_time += delta
 	for i in _door_roots.size():


### PR DESCRIPTION
Press **T** in the Hub → loads TestRealm, so the M1 save/restore loop is testable on the live GitHub Pages link (not just the local editor).

Invisible — no art/text change. Marked TEMP in code; trivially removable once M2 has its own test arena.

## Verified
- ✅ Hub + TestRealm headless scene smokes — exit 0, no script errors
- ✅ `--import` + `--export-release Web` clean
- ✅ Build served locally over HTTP — index.html / index.wasm / index.pck all HTTP 200, correct sizes, title present

Closes #110