### PR TITLE
test: boot live build directly into the save test (TEMP)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Curiosity's Doors"
-run/main_scene="res://scenes/Intro.tscn"
+run/main_scene="res://scenes/realms/TestRealm.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scripts/TestRealm.gd
+++ b/scripts/TestRealm.gd
@@ -38,7 +38,12 @@ func _process(_delta: float) -> void:
 
 
 func _refresh() -> void:
-	_label.text = "TestRealm — collected %d / %d\n[Y] collect    [S / ↓] exit to hub" % [_collected, TOKEN_COUNT]
+	var msg: String
+	if _collected < TOKEN_COUNT:
+		msg = "SAVE TEST\n\nPress  Y  to fill the dots  (%d / %d)" % [_collected, TOKEN_COUNT]
+	else:
+		msg = "SAVED.  Now REFRESH this page (F5).\n\nIf the dots are still gold, the save system works."
+	_label.text = msg
 	for i in _tokens.get_child_count():
 		var dot: ColorRect = _tokens.get_child(i) as ColorRect
 		if dot:


### PR DESCRIPTION
Temporary: `main_scene` → TestRealm so the live link opens straight into the save/restore test (no intro, no navigation). Self-documenting on-screen text. Reverted to Intro once the save system is confirmed.

Verified: default-boot scene headless smoke clean, import + Web export clean.

Refs #110