### PR TITLE
chore: restore Intro as main_scene (save test confirmed live)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Curiosity's Doors"
-run/main_scene="res://scenes/realms/TestRealm.tscn"
+run/main_scene="res://scenes/Intro.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
SaveManager verified on the live build — collected state survives a real browser refresh (IndexedDB). Revert the temporary direct-boot into TestRealm; the game opens at the Intro again. TestRealm still reachable via the Hub dev-T shortcut.

Verified: intro boots clean (headless), import + Web export clean.

Refs #110