### PR TITLE
tweak(realm1): scale Curiosity down (0.4 to 0.28)

### DIFF
--- a/assets/realms/realm1_caves/Realm1.tscn
+++ b/assets/realms/realm1_caves/Realm1.tscn
@@ -1010,7 +1010,7 @@ color = Color(0.42, 0.46, 0.62, 1)
 [node name="Curiosity" parent="." unique_id=2072415762 instance=ExtResource("1_curiosity")]
 z_index = 5
 position = Vector2(4363, 376)
-scale = Vector2(0.4, 0.4)
+scale = Vector2(0.28, 0.28)
 
 [node name="ExitDoor" type="Node2D" parent="." unique_id=1015135027]
 position = Vector2(7520, 544)


### PR DESCRIPTION
Closes #121

Curiosity reads a touch large against the Crimson Hollow; scaled 0.4 to 0.28 so the cave feels bigger and the hero more of a small traveler. Spawn derives from scale, feet stay on floor. Gate: import clean, export rc 0. Approved live by Advika.

Generated with Claude Code