### PR TITLE
tweak(hero): snappier movement — higher jump, faster walk/run

### DIFF
--- a/scripts/Curiosity.gd
+++ b/scripts/Curiosity.gd
@@ -8,10 +8,10 @@ enum State { IDLE, WALK, RUN, JUMP_START, AIR, LAND, ATTACK, DASH, HURT }
 # Drifting-traveler tuning: gravity is well below normal-platformer (~980)
 # so falls glide rather than thud. Jump magnitude is correspondingly low,
 # which keeps reachable height roughly the same while ~doubling air time.
-@export var walk_speed: float = 200.0
-@export var run_speed: float = 320.0
+@export var walk_speed: float = 265.0
+@export var run_speed: float = 420.0
 @export var gravity: float = 350.0
-@export var jump_velocity: float = -240.0
+@export var jump_velocity: float = -320.0
 @export var accel_time: float = 0.15
 @export var lantern_sway_time: float = 0.2
 


### PR DESCRIPTION
Closes #123

Tuned Curiosity for Realm 1 platforming (approved live by Advika):
- jump_velocity -240 to -320 (~82px to ~146px height)
- walk_speed 200 to 265, run_speed 320 to 420

Export gate rc 0. Verified live (Advika: 'i love it').

Generated with Claude Code