### PR TITLE
fix(realm2): never auto-return from the arrival

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -28,10 +28,10 @@ Credits: `CREDITS.md` (root) — keep updated per asset, college-portfolio gate.
 ## Live loop
 Hub.tscn ↔ Realm1 (cave traversal) ↔ Hub return. Door 1 wired.
 Realm 1 exit plays a one-line lore moment before the fade.
-Door 2 (middle) → Realm 2 liftoff setpiece (`Realm2LiftTest.tscn`): the
-arrival beat holds ~8s then auto-fades back to the Hub; ESC also returns
-to the Hub at any time (was `quit()`, a no-op on web). Respawn lands under
-Door2 via `Transition.last_door_id`.
+Door 2 (middle) → Realm 2 liftoff setpiece (`Realm2LiftTest.tscn`): no
+timer on the arrival — the player stays above the canopy until they leave
+via ESC (auto-return removed 2026-07-08, it felt like being kicked out).
+Respawn lands under Door2 via `Transition.last_door_id`.
 Door 3: stub.
 
 ## Hub — door-selection scene

--- a/scripts/Realm2LiftTest.gd
+++ b/scripts/Realm2LiftTest.gd
@@ -5,16 +5,15 @@ extends Node2D
 ## Curiosity aboard → high above the canopy: sequence complete.
 ## Controls: Curiosity's own (move/jump/dash). R restarts. ESC returns to
 ## the Hub (works headless/editor too — the Hub is just another scene).
-## Reached in-game via the Hub's middle door (Door2 → "realm_2"); after the
-## arrival beat holds for a few seconds the scene fades home on its own so a
-## web player is never stranded above the canopy.
+## Reached in-game via the Hub's middle door (Door2 → "realm_2"). The arrival
+## has no timer: the player sits above the canopy as long as they like and
+## leaves via ESC (on-screen label) until the wizard + sky door land (R2-M7+).
 ## R2_SHOT env: screenshot at 1s + quit. R2_SHOT_LIFT: jump to mid-ascent first.
 
 const BASE := "res://assets/realms/realm2_moss/"
 const LIVES_HUD := preload("res://scenes/UI/LivesHUD.tscn")
 const STARTING_LIVES: int = 3  # same rules as Realm 1
 const HUB_SCENE := "res://scenes/Hub.tscn"
-const DONE_HOLD := 8.0  # seconds to breathe above the canopy before fading home
 const FLOOR_Y := 300.0
 const CHUNK_X := 1500.0
 const CHUNK_START_Y := 420.0
@@ -656,9 +655,10 @@ func _physics_process(delta: float) -> void:
 			# walking off the hovering island at the top is a fall like any other
 			if _curi.global_position.y > _cam.global_position.y + 700.0:
 				_die()
-			# the beat has landed — breathe, then fade home to the Hub
-			elif _pt >= DONE_HOLD and not _dying:
-				_return_to_hub()
+			# NO auto-return (Advika, 2026-07-08: being yanked home after a
+			# timer felt terrible). The player leaves when THEY decide — ESC,
+			# per the on-screen label. The real ending is the wizard + sky
+			# door (R2-M7/M8); until then the arrival is theirs to sit in.
 
 
 func _process(delta: float) -> void:


### PR DESCRIPTION
The 8s auto-fade home after the arrival beat read as being kicked out of the level. Removed - the player stays above the canopy as long as they like and leaves via ESC (on-screen label). Real ending lands with the wizard + sky door (R2-M7/M8).

Export gate exit 0.

Ref #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)