### PR TITLE
fix(realm2): wizard appears 5s into the climb, not 2.5

### DIFF
--- a/scripts/Realm2LiftTest.gd
+++ b/scripts/Realm2LiftTest.gd
@@ -33,7 +33,7 @@ const WAKE_TIME := 7.0  # seconds to blossom to full color during the rise
 # long (RISING state, not the pre-tear shake), the wizard flickers into
 # existence ON the island — planted at its far end, facing Curiosity across
 # the moss (Advika, 2026-07-12: on the platform, not hovering beside it).
-const WIZARD_APPEAR_DELAY := 2.5
+const WIZARD_APPEAR_DELAY := 5.0  # was 2.5 — Advika 2026-07-12: let the ride breathe first
 # Feet on the moss top: collider top is -120 rel chunk; the figure's feet sit
 # ~134px below the 512-frame center, so origin rides 134*scale above the top.
 const WIZARD_OFFSET := Vector2(255.0, -194.0)  # open moss, clear of the right hedge's dark mass


### PR DESCRIPTION
Follow-up to #151 — Advika's tuning call: the player gets a longer beat alone with the ascent before the storm's author flickers in. One const (`WIZARD_APPEAR_DELAY` 2.5 → 5.0).

Gates: `--headless --import` exit 0, `--headless --export-release Web` exit 0. Verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)