### PR TITLE
fix(realm2): wizard entrance at 7s airborne

### DIFF
--- a/scripts/Realm2LiftTest.gd
+++ b/scripts/Realm2LiftTest.gd
@@ -33,7 +33,7 @@ const WAKE_TIME := 7.0  # seconds to blossom to full color during the rise
 # long (RISING state, not the pre-tear shake), the wizard flickers into
 # existence ON the island — planted at its far end, facing Curiosity across
 # the moss (Advika, 2026-07-12: on the platform, not hovering beside it).
-const WIZARD_APPEAR_DELAY := 5.0  # was 2.5 — Advika 2026-07-12: let the ride breathe first
+const WIZARD_APPEAR_DELAY := 7.0  # Advika 2026-07-12: a good 7s alone with the climb first
 # Feet on the moss top: collider top is -120 rel chunk; the figure's feet sit
 # ~134px below the 512-frame center, so origin rides 134*scale above the top.
 const WIZARD_OFFSET := Vector2(255.0, -194.0)  # open moss, clear of the right hedge's dark mass


### PR DESCRIPTION
Follow-up to #151 — Advika's tuning pass: the wizard now waits a good 7 seconds of true airborne climb (was 5, originally 2.5) before flickering in. One const.

Gates: import exit 0, Web export exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)